### PR TITLE
disable migrations run at startup

### DIFF
--- a/appStartUp.sh
+++ b/appStartUp.sh
@@ -3,14 +3,14 @@ set -eo pipefail
 
 export DATABASE_URL=$(echo -e ${DATABASE_URL})
 
-echo "Database - running migrations."
-if $RESET_DB; then
-    echo "Resetting DB"
-    npx prisma migrate reset --force
-else
-    echo "Running migrations"
-    npx prisma migrate deploy
-fi
+# echo "Database - running migrations."
+# if $RESET_DB; then
+#     echo "Resetting DB"
+#     npx prisma migrate reset --force
+# else
+#     echo "Running migrations"
+#     npx prisma migrate deploy
+# fi
 
 # Start the app
 pnpm start:prod


### PR DESCRIPTION
Need to disable migrations to be able to run the api against the tc-payment-api