### PR TITLE
PM-1033 - add BA field for payments

### DIFF
--- a/prisma/migrations/20250415092219_add_payment_ba_field/migration.sql
+++ b/prisma/migrations/20250415092219_add_payment_ba_field/migration.sql
@@ -1,0 +1,11 @@
+-- Add the "billing_account" field to the "payment" table
+ALTER TABLE "payment"
+ADD COLUMN "billing_account" VARCHAR(80);
+
+-- Set a value of "0" for the existing records in the "billing_account" column
+UPDATE "payment"
+SET billing_account = '0';
+
+-- Alter the "billing_account" column to make it NOT NULL
+ALTER TABLE "payment"
+ALTER COLUMN "billing_account" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -63,6 +63,7 @@ model payment {
   version                      Int?                           @default(1)
   release_date                 DateTime?                      @default(dbgenerated("(CURRENT_TIMESTAMP + '15 days'::interval)")) @db.Timestamp(6)
   payment_status               payment_status?
+  billing_account              String                         @db.VarChar(80)
   payment_method               payment_method?                @relation(fields: [payment_method_id], references: [payment_method_id], onDelete: NoAction, onUpdate: NoAction)
   winnings                     winnings                       @relation(fields: [winnings_id], references: [winning_id], onDelete: NoAction, onUpdate: NoAction)
   payment_release_associations payment_release_associations[]

--- a/src/api/admin-winning/adminWinning.controller.ts
+++ b/src/api/admin-winning/adminWinning.controller.ts
@@ -122,6 +122,7 @@ export class AdminWinningController {
         createdAt: item.createdAt.toISOString(),
         updatedAt: item.updatedAt?.toISOString() ?? '',
         releaseDate: item.releaseDate?.toISOString() ?? '',
+        billingAccount: payment?.billingAccount,
       };
     });
 
@@ -142,6 +143,7 @@ export class AdminWinningController {
         { key: 'createdAt', header: 'Created At' },
         { key: 'updatedAt', header: 'Updated At' },
         { key: 'releaseDate', header: 'Release Date' },
+        { key: 'billingAccount', header: 'Billing Account' },
       ],
     });
 

--- a/src/api/admin-winning/adminWinning.service.ts
+++ b/src/api/admin-winning/adminWinning.service.ts
@@ -110,6 +110,7 @@ export class AdminWinningService {
             currency: paymentItem.currency,
             releaseDate: paymentItem.release_date,
             category: item.category,
+            billingAccount: paymentItem.billing_account,
           })),
           createdAt: item.created_at,
           updatedAt:

--- a/src/api/winning/winning.service.ts
+++ b/src/api/winning/winning.service.ts
@@ -88,6 +88,7 @@ export class WinningService {
           net_amount: Prisma.Decimal(0),
           payment_status: '' as payment_status,
           created_by: userId,
+          billing_account: detail.billingAccount,
         };
         if (taxForms.length > 0) {
           let netAmount = detail.grossAmount;

--- a/src/dto/adminWinning.dto.ts
+++ b/src/dto/adminWinning.dto.ts
@@ -386,6 +386,14 @@ export class PaymentCreateRequestDto {
   @IsString()
   @IsNotEmpty()
   currency: string;
+
+  @ApiProperty({
+    description: 'Billing Account number for the payment',
+    example: '1231231',
+  })
+  @IsString()
+  @IsNotEmpty()
+  billingAccount: string;
 }
 
 export class WinningCreateRequestDto {
@@ -490,6 +498,7 @@ export class PaymentDetailDto {
   currency: string;
   releaseDate: Date;
   category: string;
+  billing_account: string;
 }
 
 export class WinningDto {

--- a/src/dto/adminWinning.dto.ts
+++ b/src/dto/adminWinning.dto.ts
@@ -498,7 +498,7 @@ export class PaymentDetailDto {
   currency: string;
   releaseDate: Date;
   category: string;
-  billing_account: string;
+  billingAccount: string;
 }
 
 export class WinningDto {


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PM-1033

- added "billing_account" field to the payment table in the database via migration.
- updated request DTO for create payment to require the billingAccount field
- when retrieving a payment, the billingAccount added as part of the response
- added the billingAccount field to the responses from /winnings/search and /winnings/export