### PR TITLE
PM1101 - reset payment methods

### DIFF
--- a/prisma/migrations/20250423135831_truncate_payment_methods/migration.sql
+++ b/prisma/migrations/20250423135831_truncate_payment_methods/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable
+ALTER TABLE "payoneer_payment_method" ALTER COLUMN "user_payment_method_id" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "paypal_payment_method" ALTER COLUMN "user_payment_method_id" DROP NOT NULL;
+
+UPDATE payoneer_payment_method SET user_payment_method_id = NULL;
+UPDATE paypal_payment_method   SET user_payment_method_id = NULL;
+
+DELETE FROM user_default_payment_method;
+DELETE FROM user_payment_methods;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -107,21 +107,21 @@ model payment_releases {
 
 model payoneer_payment_method {
   id                     Int                  @id @default(autoincrement())
-  user_payment_method_id String               @db.Uuid
+  user_payment_method_id String?               @db.Uuid
   user_id                String               @unique @db.VarChar(80)
   payee_id               String               @db.VarChar(50)
   payoneer_id            String?              @db.VarChar(50)
-  user_payment_methods   user_payment_methods @relation(fields: [user_payment_method_id], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "fk_payoneer_user_payment_method")
+  user_payment_methods   user_payment_methods? @relation(fields: [user_payment_method_id], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "fk_payoneer_user_payment_method")
 }
 
 model paypal_payment_method {
   id                     Int                  @id @default(autoincrement())
-  user_payment_method_id String               @db.Uuid
+  user_payment_method_id String?               @db.Uuid
   user_id                String               @unique @db.VarChar(80)
   email                  String?              @db.VarChar(150)
   payer_id               String?              @db.VarChar(50)
   country_code           String?              @db.VarChar(2)
-  user_payment_methods   user_payment_methods @relation(fields: [user_payment_method_id], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "fk_paypal_user_payment_method")
+  user_payment_methods   user_payment_methods? @relation(fields: [user_payment_method_id], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "fk_paypal_user_payment_method")
 }
 
 model reward {


### PR DESCRIPTION
- Truncates `user_payment_methods` and `user_default_payment_method`.
- makes sure to keep the data for `payoneer_payment_method` and `paypal_payment_method` tables. Not sure if this is really necessary, but it doesn't hurt to be on the safe side, and we can drop these tables completely later on.