### PR TITLE
Random fixes for trolley widget

### DIFF
--- a/src/api/payment-providers/trolley.service.ts
+++ b/src/api/payment-providers/trolley.service.ts
@@ -42,7 +42,11 @@ export class TrolleyService {
       user.email,
     );
 
-    if (foundRecipient?.length === 1) {
+    if (
+      foundRecipient?.length === 1 &&
+      // make sure it's same email address
+      foundRecipient[0].email === user.email
+    ) {
       return foundRecipient[0];
     }
 
@@ -50,7 +54,9 @@ export class TrolleyService {
       user.handle,
       { fields: BASIC_MEMBER_FIELDS },
     );
-    const address = userInfo.addresses?.[0] ?? {};
+    const address = (userInfo.addresses?.[0] ?? {}) as unknown as {
+      [key: string]: string;
+    };
 
     const recipientPayload = {
       type: 'individual' as const,
@@ -148,7 +154,7 @@ export class TrolleyService {
     const recipient = await this.getPayeeRecipient(user);
     const link = this.trolley.getRecipientPortalUrl({
       email: user.email,
-      trolleyId: recipient.trolley_id,
+      userId: user.id,
     });
 
     return { link, recipientId: recipient.trolley_id };

--- a/src/dto/adminWinning.dto.ts
+++ b/src/dto/adminWinning.dto.ts
@@ -471,6 +471,7 @@ export class WinningCreateRequestDto {
         grossAmount: 15.0,
         installmentNumber: 1,
         currency: 'string',
+        billingAccount: '1234',
       },
     ],
   })

--- a/src/shared/global/trolley.service.ts
+++ b/src/shared/global/trolley.service.ts
@@ -29,13 +29,13 @@ export class TrolleyService {
    * @throws This function assumes that `TROLLEY_WIDGET_BASE_URL`, `TROLLEY_ACCESS_KEY`,
    * and `TROLLEY_SECRET_KEY` are defined and valid. Ensure these constants are properly set.
    */
-  getRecipientPortalUrl(recipient: { email: string; trolleyId: string }) {
+  getRecipientPortalUrl(recipient: { email: string; userId: string }) {
     const widgetBaseUrl = new url.URL(TROLLEY_WIDGET_BASE_URL as string);
     const querystring = new url.URLSearchParams({
       ts: `${Math.floor(new Date().getTime() / 1000)}`,
       key: TROLLEY_ACCESS_KEY,
       email: recipient.email,
-      refid: recipient.trolleyId,
+      refid: recipient.userId,
       hideEmail: 'false',
       roEmail: 'true',
       locale: 'en',


### PR DESCRIPTION
- when looking for existing trolley recipient, make sure the email fully matches
- we need to send user id (used as reference ID when we've created the recipient) instead of trolley id
- minor swagger fix