### PR TITLE
PM-1142 - reset tax forms

### DIFF
--- a/prisma/migrations/20250425134520_truncate_tax_forms/migration.sql
+++ b/prisma/migrations/20250425134520_truncate_tax_forms/migration.sql
@@ -14,8 +14,8 @@ CREATE TYPE "tax_form_status" AS ENUM ('incomplete', 'submitted', 'reviewed', 'v
 CREATE TABLE "user_tax_form_associations" (
     "id" UUID NOT NULL DEFAULT uuid_generate_v4(),
     "user_id" VARCHAR(80) NOT NULL,
-    "tax_form_id" TEXT,
-    "date_filed" TIMESTAMP(6),
+    "tax_form_id" TEXT NOT NULL,
+    "date_filed" TIMESTAMP(6) NOT NULL,
     "tax_form_status" "tax_form_status",
 
     CONSTRAINT "user_tax_form_associations_pkey" PRIMARY KEY ("id")

--- a/prisma/migrations/20250425134520_truncate_tax_forms/migration.sql
+++ b/prisma/migrations/20250425134520_truncate_tax_forms/migration.sql
@@ -16,7 +16,7 @@ CREATE TABLE "user_tax_form_associations" (
     "user_id" VARCHAR(80) NOT NULL,
     "tax_form_id" TEXT NOT NULL,
     "date_filed" TIMESTAMP(6) NOT NULL,
-    "tax_form_status" "tax_form_status",
+    "tax_form_status" "tax_form_status" NOT NULL,
 
     CONSTRAINT "user_tax_form_associations_pkey" PRIMARY KEY ("id")
 );

--- a/prisma/migrations/20250425134520_truncate_tax_forms/migration.sql
+++ b/prisma/migrations/20250425134520_truncate_tax_forms/migration.sql
@@ -1,0 +1,31 @@
+-- DropForeignKey
+ALTER TABLE "docusign_envelopes" DROP CONSTRAINT "docusign_envelopes_user_tax_form_association_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "user_tax_form_associations" DROP CONSTRAINT "user_tax_form_associations_tax_form_id_fkey";
+
+-- AlterTable
+DROP TABLE "user_tax_form_associations";
+DROP TYPE "tax_form_status";
+
+CREATE TYPE "tax_form_status" AS ENUM ('incomplete', 'submitted', 'reviewed', 'voided');
+
+-- CreateTable
+CREATE TABLE "user_tax_form_associations" (
+    "id" UUID NOT NULL DEFAULT uuid_generate_v4(),
+    "user_id" VARCHAR(80) NOT NULL,
+    "tax_form_id" TEXT,
+    "date_filed" TIMESTAMP(6),
+    "tax_form_status" "tax_form_status",
+
+    CONSTRAINT "user_tax_form_associations_pkey" PRIMARY KEY ("id")
+);
+
+-- DropTable
+DROP TABLE "docusign_envelopes";
+
+-- DropTable
+DROP TABLE "tax_forms";
+
+-- DropEnum
+DROP TYPE "docusign_envelope_status";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,15 +19,6 @@ model audit {
   winnings    winnings @relation(fields: [winnings_id], references: [winning_id], onDelete: NoAction, onUpdate: NoAction)
 }
 
-model docusign_envelopes {
-  id                           String                     @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
-  user_tax_form_association_id String                     @db.Uuid
-  envelope_id                  String                     @db.VarChar(80)
-  template_id                  String                     @db.VarChar(80)
-  status_id                    docusign_envelope_status?
-  user_tax_form_associations   user_tax_form_associations @relation(fields: [user_tax_form_association_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
-}
-
 model origin {
   origin_id   Int        @id @default(autoincrement())
   origin_name String     @db.VarChar(255)
@@ -137,18 +128,6 @@ model reward {
   winnings    winnings  @relation(fields: [winnings_id], references: [winning_id], onDelete: NoAction, onUpdate: NoAction)
 }
 
-model tax_forms {
-  tax_form_id                    String                       @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
-  name                           String?                      @db.VarChar(30)
-  text                           String?
-  description                    String?                      @db.VarChar(255)
-  default_withholding_amount     Decimal?                     @db.Decimal(12, 2)
-  default_withholding_percentage Decimal?                     @db.Decimal(5, 5)
-  use_percentage                 Boolean?
-  e_sign_template_id             String                       @db.VarChar(80)
-  user_tax_form_associations     user_tax_form_associations[]
-}
-
 model transaction {
   id             String             @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
   user_id        String             @db.VarChar(255)
@@ -181,14 +160,9 @@ model user_payment_methods {
 model user_tax_form_associations {
   id                     String               @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
   user_id                String               @db.VarChar(80)
-  tax_form_id            String               @db.Uuid
+  tax_form_id            String?
   date_filed             DateTime?            @db.Timestamp(6)
-  withholding_amount     Decimal?             @db.Decimal
-  withholding_percentage Decimal?             @db.Decimal(5, 5)
-  status_id              tax_form_status?
-  use_percentage         Boolean?
-  docusign_envelopes     docusign_envelopes[]
-  tax_forms              tax_forms            @relation(fields: [tax_form_id], references: [tax_form_id], onDelete: NoAction, onUpdate: NoAction)
+  tax_form_status        tax_form_status?
 }
 
 model winnings {
@@ -248,13 +222,6 @@ enum action_type {
   REMOVE_TAX_FORMS
 }
 
-enum docusign_envelope_status {
-  CREATED
-  OTP_VERIFIED
-  COMPLETED
-  DECLINED
-}
-
 enum payment_method_status {
   OTP_PENDING
   OTP_VERIFIED
@@ -282,10 +249,10 @@ enum reference_type {
 }
 
 enum tax_form_status {
-  OTP_PENDING
-  OTP_VERIFIED
-  ACTIVE
-  INACTIVE
+  incomplete
+  submitted
+  reviewed
+  voided
 }
 
 enum transaction_status {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -160,9 +160,9 @@ model user_payment_methods {
 model user_tax_form_associations {
   id                     String               @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
   user_id                String               @db.VarChar(80)
-  tax_form_id            String?
-  date_filed             DateTime?            @db.Timestamp(6)
-  tax_form_status        tax_form_status?
+  tax_form_id            String
+  date_filed             DateTime            @db.Timestamp(6)
+  tax_form_status        tax_form_status
 }
 
 model winnings {

--- a/src/api/admin-winning/adminWinning.service.ts
+++ b/src/api/admin-winning/adminWinning.service.ts
@@ -17,6 +17,7 @@ import {
   WinningUpdateRequestDto,
   PaymentStatus,
   AuditPayoutDto,
+  WinningsCategory,
 } from 'src/dto/adminWinning.dto';
 import { TaxFormRepository } from '../repository/taxForm.repo';
 import { PaymentMethodRepository } from '../repository/paymentMethod.repo';
@@ -94,30 +95,29 @@ export class AdminWinningService {
           type: item.type,
           winnerId: item.winner_id,
           origin: item.origin?.origin_name,
-          category: item.category,
-          title: item.title,
-          description: item.description,
-          externalId: item.external_id,
-          attributes: item.attributes,
+          category: (item.category ?? '') as WinningsCategory,
+          title: item.title as string,
+          description: item.description as string,
+          externalId: item.external_id as string,
+          attributes: (item.attributes ?? {}) as object,
           details: item.payment?.map((paymentItem) => ({
             id: paymentItem.payment_id,
             netAmount: Number(paymentItem.net_amount),
             grossAmount: Number(paymentItem.gross_amount),
             totalAmount: Number(paymentItem.total_amount),
-            installmentNumber: paymentItem.installment_number,
-            datePaid: paymentItem.date_paid ?? undefined,
-            status: paymentItem.payment_status,
-            currency: paymentItem.currency,
-            releaseDate: paymentItem.release_date,
-            category: item.category,
+            installmentNumber: paymentItem.installment_number as number,
+            datePaid: (paymentItem.date_paid ?? undefined) as Date,
+            status: paymentItem.payment_status as PaymentStatus,
+            currency: paymentItem.currency as string,
+            releaseDate: paymentItem.release_date as Date,
+            category: item.category as string,
             billingAccount: paymentItem.billing_account,
           })),
-          createdAt: item.created_at,
-          updatedAt:
-            item.payment?.[0].date_paid ??
+          createdAt: item.created_at as Date,
+          updatedAt: (item.payment?.[0].date_paid ??
             item.payment?.[0].updated_at ??
-            undefined,
-          releaseDate: item.payment?.[0]?.release_date,
+            undefined) as Date,
+          releaseDate: item.payment?.[0]?.release_date as Date,
         })),
         pagination: {
           totalItems: count,

--- a/src/api/winning/winning.service.ts
+++ b/src/api/winning/winning.service.ts
@@ -67,10 +67,7 @@ export class WinningService {
           create: [] as Partial<payment>[],
         },
       };
-      const taxForms = await this.taxFormRepo.findTaxFormByUserId(
-        body.winnerId,
-        tx,
-      );
+
       const payrollPayment = (body.attributes || {})['payroll'] === true;
 
       const hasPaymentMethod =
@@ -90,22 +87,9 @@ export class WinningService {
           created_by: userId,
           billing_account: detail.billingAccount,
         };
-        if (taxForms.length > 0) {
-          let netAmount = detail.grossAmount;
-          for (const taxForm of taxForms) {
-            const withholding = taxForm.withholding_amount;
-            netAmount -= withholding;
-            if (netAmount <= 0) {
-              netAmount = 0;
-              break;
-            }
-          }
-          paymentModel.net_amount = Prisma.Decimal(netAmount);
-          paymentModel.payment_status = PaymentStatus.OWED;
-        } else {
-          paymentModel.net_amount = Prisma.Decimal(detail.grossAmount);
-          paymentModel.payment_status = PaymentStatus.ON_HOLD;
-        }
+
+        paymentModel.net_amount = Prisma.Decimal(detail.grossAmount);
+        paymentModel.payment_status = PaymentStatus.ON_HOLD;
 
         if (!hasPaymentMethod) {
           paymentModel.payment_status = PaymentStatus.ON_HOLD;

--- a/src/api/winning/winning.service.ts
+++ b/src/api/winning/winning.service.ts
@@ -91,9 +91,6 @@ export class WinningService {
         paymentModel.net_amount = Prisma.Decimal(detail.grossAmount);
         paymentModel.payment_status = PaymentStatus.ON_HOLD;
 
-        if (!hasPaymentMethod) {
-          paymentModel.payment_status = PaymentStatus.ON_HOLD;
-        }
         if (payrollPayment) {
           paymentModel.payment_status = PaymentStatus.PAID;
         }

--- a/src/dto/adminWinning.dto.ts
+++ b/src/dto/adminWinning.dto.ts
@@ -93,10 +93,10 @@ export enum WinningsCategory {
 }
 
 export enum TaxFormStatus {
-  Active = 'ACTIVE',
-  Inactive = 'INACTIVE',
-  Verified = 'OTP_VERIFIED',
-  OtpPending = 'OTP_PENDING',
+  Incomplete = 'incomplete',
+  Submitted = 'submitted',
+  Reviewed = 'reviewed',
+  Voided = 'voided',
 }
 
 export enum PaymentStatus {
@@ -528,7 +528,7 @@ export class AuditPayoutDto {
   status: string;
   totalNetAmount: number;
   createdAt: Date;
-  metadata: object;
+  metadata: string;
   paymentMethodUsed: string;
   externalTransactionDetails: object;
 }

--- a/src/dto/taxForm.dto.ts
+++ b/src/dto/taxForm.dto.ts
@@ -1,13 +1,9 @@
+import { TaxFormStatus } from './adminWinning.dto';
+
 export class TaxFormQueryResult {
   id: string;
   user_id: string;
   tax_form_id: string;
-  name: string;
-  text: string;
-  description: string;
   date_filed: Date;
-  withholding_amount: number;
-  withholding_percentage: number;
-  status_id: string;
-  use_percentage: number;
+  tax_form_status: TaxFormStatus;
 }

--- a/src/shared/global/prisma.service.ts
+++ b/src/shared/global/prisma.service.ts
@@ -18,6 +18,10 @@ export class PrismaService
         { level: 'error', emit: 'event' },
       ],
     });
+
+    // this.$on("query", async (e) => {
+    //   console.log(`${e.query} ${e.params}`)
+    // });
   }
 
   async onModuleInit() {

--- a/src/shared/global/prisma.service.ts
+++ b/src/shared/global/prisma.service.ts
@@ -18,10 +18,6 @@ export class PrismaService
         { level: 'error', emit: 'event' },
       ],
     });
-
-    // this.$on("query", async (e) => {
-    //   console.log(`${e.query} ${e.params}`)
-    // });
   }
 
   async onModuleInit() {


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PM-1142
Migration file to:
- drop `docusign_envelopes` table & related enums
- drop & recreate `user_tax_form_associations` table with columns: user_id, tax_form_id, date_filed, tax_form_status.
- drop table `tax_forms`
- updated enum for `tax_form_status` to reflect status from trolley

Updated services & controller to get rid of handling "net_amount" based on filled-in tax forms.
