### PR TITLE
PM-1161 - reconcile payments on user details updates

### DIFF
--- a/src/api/admin/admin.module.ts
+++ b/src/api/admin/admin.module.ts
@@ -5,9 +5,10 @@ import { TaxFormRepository } from '../repository/taxForm.repo';
 import { PaymentMethodRepository } from '../repository/paymentMethod.repo';
 import { WinningsRepository } from '../repository/winnings.repo';
 import { TopcoderModule } from 'src/shared/topcoder/topcoder.module';
+import { PaymentsService } from 'src/shared/payments';
 
 @Module({
-  imports: [TopcoderModule],
+  imports: [TopcoderModule, PaymentsService],
   controllers: [AdminController],
   providers: [
     AdminService,

--- a/src/api/admin/admin.module.ts
+++ b/src/api/admin/admin.module.ts
@@ -5,10 +5,10 @@ import { TaxFormRepository } from '../repository/taxForm.repo';
 import { PaymentMethodRepository } from '../repository/paymentMethod.repo';
 import { WinningsRepository } from '../repository/winnings.repo';
 import { TopcoderModule } from 'src/shared/topcoder/topcoder.module';
-import { PaymentsService } from 'src/shared/payments';
+import { PaymentsModule } from 'src/shared/payments';
 
 @Module({
-  imports: [TopcoderModule, PaymentsService],
+  imports: [TopcoderModule, PaymentsModule],
   controllers: [AdminController],
   providers: [
     AdminService,

--- a/src/api/repository/winnings.repo.ts
+++ b/src/api/repository/winnings.repo.ts
@@ -129,7 +129,7 @@ export class WinningsRepository {
         CASE WHEN utx.tax_form_status = 'ACTIVE' THEN TRUE ELSE FALSE END as "taxFormSetupComplete",
         CASE WHEN upm.status = 'CONNECTED' THEN TRUE ELSE FALSE END as "payoutSetupComplete"
       FROM user_payment_methods upm
-      LEFT JOIN user_tax_form_associations utx ON upm.user_id = utx.user_id
+      LEFT JOIN user_tax_form_associations utx ON upm.user_id = utx.user_id AND utx.tax_form_status = 'ACTIVE'
       WHERE upm.user_id IN (${Prisma.join(uniq(winnings.map((w) => w.winner_id)))})
     `;
 

--- a/src/api/webhooks/trolley/handlers/recipient-account.handler.ts
+++ b/src/api/webhooks/trolley/handlers/recipient-account.handler.ts
@@ -7,10 +7,14 @@ import {
   RecipientAccountWebhookEvent,
 } from './recipient-account.types';
 import { payment_method_status } from '@prisma/client';
+import { PaymentsService } from 'src/shared/payments';
 
 @Injectable()
 export class RecipientAccountHandler {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly paymentsService: PaymentsService,
+  ) {}
 
   /**
    * Updates the status of the related trolley user_payment_method based on the presence of primary
@@ -126,6 +130,8 @@ export class RecipientAccountHandler {
     }
 
     await this.updateUserPaymentMethod(payload.recipientId);
+
+    await this.paymentsService.reconcileUserPayments(recipient.user_id);
   }
 
   /**
@@ -161,6 +167,10 @@ export class RecipientAccountHandler {
 
     await this.updateUserPaymentMethod(
       recipientPaymentMethod.trolley_recipient.trolley_id,
+    );
+
+    await this.paymentsService.reconcileUserPayments(
+      recipientPaymentMethod.trolley_recipient.user_id,
     );
   }
 }

--- a/src/api/webhooks/trolley/trolley.service.ts
+++ b/src/api/webhooks/trolley/trolley.service.ts
@@ -22,7 +22,10 @@ if (!trolleyWhHmac) {
 export class TrolleyService {
   constructor(
     @Inject('trolleyHandlerFns')
-    private readonly handlers,
+    private readonly handlers: Map<
+      string,
+      (eventPayload: any) => Promise<unknown>
+    >,
     private readonly prisma: PrismaService,
   ) {}
 

--- a/src/api/webhooks/webhooks.module.ts
+++ b/src/api/webhooks/webhooks.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { WebhooksController } from './webhooks.controller';
 import { TrolleyService } from './trolley/trolley.service';
 import { TrolleyWebhookHandlers } from './trolley/handlers';
+import { PaymentsModule } from 'src/shared/payments';
 
 @Module({
-  imports: [],
+  imports: [PaymentsModule],
   controllers: [WebhooksController],
   providers: [...TrolleyWebhookHandlers, TrolleyService],
 })

--- a/src/shared/payments/index.ts
+++ b/src/shared/payments/index.ts
@@ -1,0 +1,2 @@
+export * from './payments.module';
+export * from './payments.service';

--- a/src/shared/payments/payments.module.ts
+++ b/src/shared/payments/payments.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { PaymentsService } from './payments.service';
+
+@Module({
+  providers: [PaymentsService],
+  exports: [PaymentsService],
+})
+export class PaymentsModule {}

--- a/src/shared/payments/payments.service.ts
+++ b/src/shared/payments/payments.service.ts
@@ -1,0 +1,100 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../global/prisma.service';
+import { payment_status, Prisma } from '@prisma/client';
+import { uniq } from 'lodash';
+
+@Injectable()
+export class PaymentsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Retrieves the payout setup status for a list of users.
+   *
+   * This method queries the database to determine whether each user's payout setup
+   * is complete or still in progress. A user's payout setup is considered complete
+   * if their tax form status is 'ACTIVE' and their payment method status is 'CONNECTED'.
+   *
+   * @param userIds - An array of user IDs for which to retrieve the payout setup status.
+   * @returns A promise that resolves to an object containing two arrays:
+   *          - `complete`: An array of user IDs whose payout setup is complete.
+   *          - `inProgress`: An array of user IDs whose payout setup is still in progress.
+   *
+   * @throws Will throw an error if the database query fails.
+   */
+  private async getUsersPayoutStatus(userIds: string[]) {
+    const usersPayoutStatus = await this.prisma.$queryRaw<
+      {
+        userId: string;
+        setupComplete: boolean;
+      }[]
+    >`
+        SELECT
+          upm.user_id as "userId",
+          CASE WHEN utx.tax_form_status = 'ACTIVE' AND upm.status = 'CONNECTED' THEN TRUE ELSE FALSE END as "setupComplete"
+        FROM user_payment_methods upm
+        LEFT JOIN user_tax_form_associations utx ON upm.user_id = utx.user_id AND utx.tax_form_status = 'ACTIVE'
+        WHERE upm.user_id IN (${Prisma.join(uniq(userIds))})
+      `;
+
+    const setupStatusMap = {
+      complete: [] as string[],
+      inProgress: [] as string[],
+    };
+
+    usersPayoutStatus.forEach((user) => {
+      setupStatusMap[user.setupComplete ? 'complete' : 'inProgress'].push(
+        user.userId,
+      );
+    });
+
+    return setupStatusMap;
+  }
+
+  /**
+   * Updates the payment status of users' payments based on the provided user IDs and the desired status.
+   *
+   * @param userIds - An array of user IDs whose payment statuses need to be updated.
+   * @param setOnHold - A boolean indicating whether to set the payment status to "ON_HOLD" (true)
+   *                    or revert it to "OWED" (false).
+   * @returns A raw Prisma query that updates the payment statuses in the database.
+   *
+   * The function performs the following:
+   * - Updates the `payment_status` field in the `payment` table.
+   * - Changes the status to "ON_HOLD" if `setOnHold` is true, or to "OWED" if `setOnHold` is false.
+   * - Ensures that only payments associated with the specified users' winnings are updated.
+   */
+  private updateUserPaymentsStatus(userIds: string[], setOnHold: boolean) {
+    return this.prisma.$queryRaw`
+      UPDATE payment
+      SET payment_status = ${setOnHold ? payment_status.ON_HOLD : payment_status.OWED}::payment_status
+      FROM winnings w
+      WHERE payment.payment_status = ${setOnHold ? payment_status.OWED : payment_status.ON_HOLD}::payment_status
+        AND payment.winnings_id = w.winning_id
+        AND w.winner_id IN (${Prisma.join(uniq(userIds))});
+    `;
+  }
+
+  /**
+   * Reconciles the payment statuses of the specified users by updating their payment records.
+   *
+   * @param userIds - A list of user IDs whose payment statuses need to be reconciled.
+   *
+   * The method performs the following steps:
+   * 1. Retrieves the payout status of the specified users.
+   * 2. Updates the payment status for users whose payments are complete to `OWED`.
+   * 3. Updates the payment status for users whose payments are in progress to `ON_HOLD`.
+   *
+   * This ensures that the payment statuses are accurately reflected in the system.
+   */
+  async reconcileUserPayments(...userIds: string[]) {
+    const usersPayoutStatus = await this.getUsersPayoutStatus(userIds);
+
+    if (usersPayoutStatus.complete.length) {
+      await this.updateUserPaymentsStatus(usersPayoutStatus.complete, false);
+    }
+
+    if (usersPayoutStatus.inProgress.length) {
+      await this.updateUserPaymentsStatus(usersPayoutStatus.inProgress, true);
+    }
+  }
+}


### PR DESCRIPTION
Reconcile payments on user details updates:
- if payout setup is not complete (tax form + payment method), then new payments, and payments with a status of "owed" are set to on_hold
- if payout setup is complete (tax form + payment method), then new payments, and payments with a status of "on_hold" are set to owed