### PR TITLE
PM-1219 - switch from using winnings ids as externalId 

### DIFF
--- a/src/api/withdrawal/withdrawal.service.ts
+++ b/src/api/withdrawal/withdrawal.service.ts
@@ -3,7 +3,7 @@ import { ENV_CONFIG } from 'src/config';
 import { PrismaService } from 'src/shared/global/prisma.service';
 import { TaxFormRepository } from '../repository/taxForm.repo';
 import { PaymentMethodRepository } from '../repository/paymentMethod.repo';
-import { payment_status } from '@prisma/client';
+import { payment_releases, payment_status, PrismaClient } from '@prisma/client';
 import { TrolleyService } from 'src/shared/global/trolley.service';
 import { PaymentsService } from 'src/shared/payments';
 
@@ -90,6 +90,65 @@ export class WithdrawalService {
     return totalAmount;
   }
 
+  private async createDbPaymentRelease(
+    tx: PrismaClient,
+    userId: string,
+    totalAmount: number,
+    paymentMethodId: number,
+    recipientId: string,
+    winnings: ReleasableWinningRow[],
+  ) {
+    try {
+      const paymentRelease = await tx.payment_releases.create({
+        data: {
+          user_id: userId,
+          total_net_amount: totalAmount,
+          status: payment_status.PROCESSING,
+          payment_method_id: paymentMethodId,
+          payee_id: recipientId,
+          payment_release_associations: {
+            createMany: {
+              data: winnings.map((w) => ({
+                payment_id: w.paymentId,
+              })),
+            },
+          },
+        },
+      });
+
+      this.logger.log(
+        `DB payment_release created successfully. ID: ${paymentRelease.payment_release_id}`,
+      );
+
+      return paymentRelease;
+    } catch (error) {
+      const errorMsg = `Failed to create DB payment_release: ${error.message}`;
+      this.logger.error(errorMsg, error);
+      throw new Error(errorMsg);
+    }
+  }
+
+  private async updateDbReleaseRecord(
+    tx: PrismaClient,
+    paymentRelease: payment_releases,
+    externalTxId: string,
+  ) {
+    try {
+      await tx.payment_releases.update({
+        where: { payment_release_id: paymentRelease.payment_release_id },
+        data: { external_transaction_id: externalTxId },
+      });
+
+      this.logger.log(
+        `DB payment_release[${paymentRelease.payment_release_id}] updated successfully with trolley payment id: ${externalTxId}`,
+      );
+    } catch (error) {
+      const errorMsg = `Failed to update DB payment_release: ${error.message}`;
+      this.logger.error(errorMsg, error);
+      throw new Error(errorMsg);
+    }
+  }
+
   async withdraw(userId: string, userHandle: string, winningsIds: string[]) {
     this.logger.log('Processing withdrawal request');
     const hasActiveTaxForm = await this.taxFormRepo.hasActiveTaxForm(userId);
@@ -124,16 +183,31 @@ export class WithdrawalService {
         throw new Error(`Trolley recipient not found for user '${userId}'!`);
       }
 
-      const paymentBatch = await this.trolleyService.startBatchPayment(
-        recipient.trolley_id,
-        `${userId}_${userHandle}`,
+      const paymentRelease = await this.createDbPaymentRelease(
+        tx as PrismaClient,
+        userId,
         totalAmount,
-        winningsIds,
+        connectedPaymentMethod.payment_method_id,
+        recipient.trolley_id,
+        winnings,
       );
 
-      if (!paymentBatch) {
-        return;
-      }
+      const paymentBatch = await this.trolleyService.startBatchPayment(
+        `${userId}_${userHandle}`,
+      );
+
+      const trolleyPayment = await this.trolleyService.createPayment(
+        recipient.trolley_id,
+        paymentBatch.id,
+        totalAmount,
+        paymentRelease.payment_release_id,
+      );
+
+      await this.updateDbReleaseRecord(
+        tx as PrismaClient,
+        paymentRelease,
+        trolleyPayment.id,
+      );
 
       try {
         await this.paymentsService.updatePaymentProcessingState(
@@ -149,32 +223,11 @@ export class WithdrawalService {
       }
 
       try {
-        const paymentRelease = await tx.payment_releases.create({
-          data: {
-            user_id: userId,
-            total_net_amount: totalAmount,
-            status: payment_status.PROCESSING,
-            payment_method_id: connectedPaymentMethod.payment_method_id,
-            payee_id: recipient.trolley_id,
-            external_transaction_id: paymentBatch.id,
-            payment_release_associations: {
-              createMany: {
-                data: winnings.map((w) => ({
-                  payment_id: w.paymentId,
-                })),
-              },
-            },
-          },
-        });
-
         await this.trolleyService.startProcessingPayment(paymentBatch.id);
-
-        this.logger.log(
-          `Payment release created successfully. ID: ${paymentRelease.payment_release_id}`,
-        );
       } catch (error) {
-        this.logger.error(`Failed to create payment release: ${error.message}`);
-        throw new Error('Failed to release payment!');
+        const errorMsg = `Failed to release payment: ${error.message}`;
+        this.logger.error(errorMsg, error);
+        throw new Error(errorMsg);
       }
     });
   }

--- a/src/shared/payments/payments.service.ts
+++ b/src/shared/payments/payments.service.ts
@@ -132,7 +132,7 @@ export class PaymentsService {
   }
 
   async updatePaymentReleaseState(
-    externalTransactionId: string,
+    paymentId: string,
     status: string,
     transaction?: Prisma.TransactionClient,
     metadata?: JsonObject,
@@ -141,7 +141,7 @@ export class PaymentsService {
     try {
       const r = await prismaClient.payment_releases.updateMany({
         where: {
-          external_transaction_id: externalTransactionId,
+          payment_release_id: paymentId,
         },
         data: {
           status,


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PM-1219
- Use the payment_release_id as "External ID" on the trolley payment. When the payment processed/failed/returned events come back, use the externalId (as payment_release_id) to update db records
- improved error handling/messaging & logging