### PR TITLE
PM-1217 prevent duplicate payments

### DIFF
--- a/src/api/withdrawal/withdrawal.service.ts
+++ b/src/api/withdrawal/withdrawal.service.ts
@@ -232,8 +232,6 @@ export class WithdrawalService {
         }
       });
     } catch (error) {
-      console.error(error.code, error.Code, error);
-      console.log(JSON.stringify(error, null, 2));
       if (error.code === 'P2010' && error.meta?.code === '55P03') {
         this.logger.error(
           'Payment request denied because payment row was locked previously!',

--- a/src/api/withdrawal/withdrawal.service.ts
+++ b/src/api/withdrawal/withdrawal.service.ts
@@ -48,6 +48,7 @@ export class WithdrawalService {
       FROM payment p INNER JOIN winnings w on p.winnings_id = w.winning_id
       AND p.installment_number = 1
       WHERE p.winnings_id = ANY(${winningsIds}::uuid[]) AND w.winner_id = ${userId}
+      FOR UPDATE
     `;
 
     if (winnings.length < winningsIds.length) {


### PR DESCRIPTION
Prevents duplicate payments by locking the related winnings & payment rows until we're done with the transaction.

Used "nowait" with the lock to prevent deadlocks & to fail immediately.