### PR TITLE
Update returned payment handling

### DIFF
--- a/src/api/admin/admin.service.ts
+++ b/src/api/admin/admin.service.ts
@@ -348,9 +348,12 @@ export class AdminService {
     currentVersion: number,
   ) {
     let setDatePaidNull = false;
-    if (
-      (oldPaymentStatus === PaymentStatus.PAID ||
-        oldPaymentStatus === PaymentStatus.PROCESSING) &&
+    if ([
+      PaymentStatus.PAID,
+      PaymentStatus.PROCESSING,
+      PaymentStatus.RETURNED,
+      PaymentStatus.FAILED,
+    ].includes(oldPaymentStatus as PaymentStatus) &&
       newPaymentStatus === PaymentStatus.OWED
     ) {
       setDatePaidNull = true;

--- a/src/api/webhooks/trolley/handlers/payment.handler.ts
+++ b/src/api/webhooks/trolley/handlers/payment.handler.ts
@@ -34,7 +34,11 @@ export class PaymentHandler {
         paymentId,
         payload.status.toUpperCase() as payment_status,
         payload.status.toUpperCase(),
-        { failureMessage: payload.failureMessage },
+        {
+          failureMessage: payload.failureMessage,
+          returnedNote: payload.returnedNote,
+          errors: payload.errors?.join(', '),
+        },
       );
 
       return;
@@ -56,6 +60,7 @@ export class PaymentHandler {
       INNER JOIN public.payment_release_associations pra
       ON pra.payment_id = p.payment_id
       WHERE pra.payment_release_id::text = ${paymentId}
+      FOR UPDATE
     `
     ).map((w) => w.id);
 

--- a/src/api/webhooks/trolley/handlers/payment.types.ts
+++ b/src/api/webhooks/trolley/handlers/payment.types.ts
@@ -23,6 +23,8 @@ export interface PaymentProcessedEventData {
   fees: string;
   targetAmount: string; // net amount
   failureMessage: string | null;
+  errors?: string[];
+  returnedNote?: string;
   memo: string | null;
   batch: {
     id: string;


### PR DESCRIPTION
Update returned payment handling:
- when admin resets return payment, make sure datePaid is set to null
- do not handle processed events after payment was marked as "Returned"
- add errors to failed payments