### PR TITLE
PM-1257 - handle wipro users payout

### DIFF
--- a/prisma/migrations/20250423135831_truncate_payment_methods/migration.sql
+++ b/prisma/migrations/20250423135831_truncate_payment_methods/migration.sql
@@ -7,5 +7,11 @@ ALTER TABLE "paypal_payment_method" ALTER COLUMN "user_payment_method_id" DROP N
 UPDATE payoneer_payment_method SET user_payment_method_id = NULL;
 UPDATE paypal_payment_method   SET user_payment_method_id = NULL;
 
-DELETE FROM user_default_payment_method;
-DELETE FROM user_payment_methods;
+DROP TABLE user_default_payment_method;
+
+DELETE FROM user_payment_methods
+WHERE payment_method_id NOT IN (
+  SELECT payment_method_id
+  FROM payment_method
+  WHERE payment_method_type IN ('Wipro Payroll', 'Trolley')
+);

--- a/src/api/payment-providers/trolley.service.ts
+++ b/src/api/payment-providers/trolley.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { UserInfo } from 'src/dto/user.dto';
 import { TrolleyService as Trolley } from 'src/shared/global/trolley.service';
 import { PrismaService } from 'src/shared/global/prisma.service';
@@ -157,6 +157,12 @@ export class TrolleyService {
    * @returns A URL string to the Trolley user portal.
    */
   async getPortalUrlForUser(user: UserInfo) {
+    if (user.email.toLowerCase().indexOf('@wipro.com') > -1) {
+      throw new BadRequestException(
+        'Please contact Topgear support to withdrawal your payments',
+      );
+    }
+
     const recipient = await this.getPayeeRecipient(user);
     const link = this.trolley.getRecipientPortalUrl({
       email: user.email,


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PM-1257
- modifies the migration file from when we truncated user_payment_methods to:
  - drop `user_default_payment_method` table
  - delete everything in `user_payment_methods` table, except users that have a payment method of either "Trolley" or "wipro payroll".
  - NOTE: this will not run in dev. I'll set the check-sum for the migration in the migration table, otherwise the migration will be out-of-sync.
- when new payment (winning) is made for payroll (wipro user), sets the wipro payroll payment method for the user (if not already set)
- prevents wipro user from fetching trolley portal link (so user can't fetch via direct call either)