### PR TITLE
PM-1112 - apply challenge payments at end of challenge

### DIFF
--- a/src/api/api.module.ts
+++ b/src/api/api.module.ts
@@ -17,6 +17,7 @@ import { WinningsModule } from './winnings/winnings.module';
 import { UserModule } from './user/user.module';
 import { WalletModule } from './wallet/wallet.module';
 import { WithdrawalModule } from './withdrawal/withdrawal.module';
+import { ChallengesModule } from './challenges/challenges.module';
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { WithdrawalModule } from './withdrawal/withdrawal.module';
     UserModule,
     WalletModule,
     WithdrawalModule,
+    ChallengesModule,
   ],
   controllers: [HealthCheckController],
   providers: [

--- a/src/api/challenges/challenges.controller.ts
+++ b/src/api/challenges/challenges.controller.ts
@@ -1,14 +1,12 @@
-import { Param } from '@nestjs/common';
-import { Controller, Post, Body, HttpCode, HttpStatus } from '@nestjs/common';
-import { ApiParam } from '@nestjs/swagger';
+import { Controller, Post, Param, HttpCode, HttpStatus } from '@nestjs/common';
 import {
   ApiOperation,
+  ApiParam,
   ApiTags,
   ApiResponse,
-  ApiBody,
   ApiBearerAuth,
 } from '@nestjs/swagger';
-import { UserInfo } from 'os';
+import { UserInfo } from 'src/dto/user.type';
 import { M2mScope } from 'src/core/auth/auth.constants';
 import { AllowedM2mScope, M2M, User } from 'src/core/auth/decorators';
 import { ResponseDto, ResponseStatusType } from 'src/dto/api-response.dto';
@@ -44,13 +42,16 @@ export class ChallengesController {
     @Param('challengeId') challengeId: string,
     @User() user: UserInfo,
   ): Promise<ResponseDto<string>> {
-    const result = await this.challengesService.generateChallengePayments(
-      challengeId,
-      user.id,
-    );
+    const result = new ResponseDto<string>();
 
-    result.status = ResponseStatusType.SUCCESS;
-    if (result.error) {
+    try {
+      await this.challengesService.generateChallengePayments(
+        challengeId,
+        user.id,
+      );
+      result.status = ResponseStatusType.SUCCESS;
+    } catch (e) {
+      result.error = e;
       result.status = ResponseStatusType.ERROR;
     }
 

--- a/src/api/challenges/challenges.controller.ts
+++ b/src/api/challenges/challenges.controller.ts
@@ -1,0 +1,59 @@
+import { Param } from '@nestjs/common';
+import { Controller, Post, Body, HttpCode, HttpStatus } from '@nestjs/common';
+import { ApiParam } from '@nestjs/swagger';
+import {
+  ApiOperation,
+  ApiTags,
+  ApiResponse,
+  ApiBody,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { UserInfo } from 'os';
+import { M2mScope } from 'src/core/auth/auth.constants';
+import { AllowedM2mScope, M2M, User } from 'src/core/auth/decorators';
+import { ResponseDto, ResponseStatusType } from 'src/dto/api-response.dto';
+import { ChallengesService } from './challenges.service';
+
+@ApiTags('Challenges')
+@Controller('/challenges')
+@ApiBearerAuth()
+export class ChallengesController {
+  constructor(
+    private readonly challengesService: ChallengesService,
+  ) {}
+
+  @Post('/:challengeId')
+  @M2M()
+  @AllowedM2mScope(M2mScope.CreatePayments)
+  @ApiOperation({
+    summary: 'Create winning with payments.',
+    description: 'User must have "create:payments" scope to access.',
+  })
+  @ApiParam({
+    name: 'challengeId',
+    description: 'The ID of the challenge',
+    example: '2ccba36d-8db7-49da-94c9-b6c5b7bf47fb',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Create winnings successfully.',
+    type: ResponseDto<string>,
+  })
+  @HttpCode(HttpStatus.CREATED)
+  async createWinnings(
+    @Param('challengeId') challengeId: string,
+    @User() user: UserInfo,
+  ): Promise<ResponseDto<string>> {
+    const result = await this.challengesService.generateChallengePayments(
+      challengeId,
+      user.id,
+    );
+
+    result.status = ResponseStatusType.SUCCESS;
+    if (result.error) {
+      result.status = ResponseStatusType.ERROR;
+    }
+
+    return result;
+  }
+}

--- a/src/api/challenges/challenges.module.ts
+++ b/src/api/challenges/challenges.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TopcoderModule } from 'src/shared/topcoder/topcoder.module';
+import { ChallengesService } from './challenges.service';
+import { ChallengesController } from './challenges.controller';
+import { WinningsModule } from '../winnings/winnings.module';
+
+@Module({
+  imports: [TopcoderModule, WinningsModule],
+  controllers: [ChallengesController],
+  providers: [
+    ChallengesService,
+  ],
+})
+export class ChallengesModule {}

--- a/src/api/challenges/challenges.module.ts
+++ b/src/api/challenges/challenges.module.ts
@@ -3,12 +3,14 @@ import { TopcoderModule } from 'src/shared/topcoder/topcoder.module';
 import { ChallengesService } from './challenges.service';
 import { ChallengesController } from './challenges.controller';
 import { WinningsModule } from '../winnings/winnings.module';
+import { WinningsRepository } from '../repository/winnings.repo';
 
 @Module({
   imports: [TopcoderModule, WinningsModule],
   controllers: [ChallengesController],
   providers: [
     ChallengesService,
+    WinningsRepository,
   ],
 })
 export class ChallengesModule {}

--- a/src/api/challenges/challenges.service.ts
+++ b/src/api/challenges/challenges.service.ts
@@ -1,0 +1,185 @@
+import { includes, isEmpty, sortBy, find, camelCase, groupBy } from 'lodash';
+import { Injectable } from '@nestjs/common';
+import { ENV_CONFIG } from 'src/config';
+import { Logger } from 'src/shared/global';
+import { Challenge, ChallengeResource, ResourceRole } from './models';
+import { BillingAccountsService } from 'src/shared/topcoder/billing-accounts.service';
+import { TopcoderM2MService } from 'src/shared/topcoder/topcoder-m2m.service';
+import { WinningsService } from '../winnings/winnings.service';
+import { WinningsCategory, WinningsType } from 'src/dto/winning.dto';
+
+const placeToOrdinal = (place: number) => {
+  if (place === 1) return "1st";
+  if (place === 2) return "2nd";
+  if (place === 3) return "3rd";
+
+  return `${place}th`;
+}
+
+const {
+  TOPCODER_API_V6_BASE_URL,
+  TGBillingAccounts,
+} = ENV_CONFIG;
+
+
+@Injectable()
+export class ChallengesService {
+  private readonly logger = new Logger(ChallengesService.name);
+
+  constructor(
+    private readonly m2MService: TopcoderM2MService,
+    private readonly baService: BillingAccountsService,
+    private readonly winningsService: WinningsService,
+  ) {}
+
+  async getChallenge(challengeId: string) {
+    const requestUrl = `${TOPCODER_API_V6_BASE_URL}/challenges/${challengeId}`;
+
+    try {
+      const challenge = await this.m2MService.m2mFetch<Challenge>(requestUrl);
+      this.logger.log(JSON.stringify(challenge, null, 2));
+      return challenge;
+    } catch(e) {
+      this.logger.log('here', e);
+    }
+  }
+
+  async getChallengeResources(challengeId: string) {
+    try {
+      const resources = await this.m2MService.m2mFetch<ChallengeResource[]>(`${TOPCODER_API_V6_BASE_URL}/resources?challengeId=${challengeId}`);
+      const resourceRoles = await this.m2MService.m2mFetch<ResourceRole[]>(`${TOPCODER_API_V6_BASE_URL}/resource-roles`);
+
+      const rolesMap = resourceRoles.reduce((map, role) => {
+        map[role.id] = camelCase(role.name);
+        return map;
+      }, {} as {[key: string]: string});
+
+      return groupBy(resources, (r) => rolesMap[r.roleId]) as {[role: string]: ChallengeResource[]};
+    } catch(e) {
+      this.logger.log('here', e);
+    }
+  }
+
+  async getChallengePayments(challenge: Challenge) {
+    this.logger.log(
+      `Generating payments for challenge ${challenge.name} (${challenge.id}).`
+    );
+    const challengeResources = await this.getChallengeResources(challenge.id);
+
+    if (!challengeResources || isEmpty(challengeResources)) {
+      throw new Error('Missing challenge resources!');
+    }
+
+    const payments = [] as {
+      handle: string;
+      amount: number;
+      userId: string;
+      type: WinningsCategory;
+      description?: string;
+    }[];
+
+    const { prizeSets, winners, reviewers } = challenge;
+
+    // generate placement payments
+    const placementPrizes = sortBy(find(prizeSets, {type: 'PLACEMENT'})?.prizes, 'value');
+    if (placementPrizes.length !== winners.length) {
+      throw new Error('Task has incorrect number of placement prizes!');
+    }
+
+    winners.forEach((winner) => {
+      payments.push({
+        handle: winner.handle,
+        amount: placementPrizes[winner.placement - 1].value,
+        userId: winner.userId.toString(),
+        type: challenge.task.isTask ? WinningsCategory.TASK_PAYMENT : WinningsCategory.CONTEST_PAYMENT,
+        description: challenge.type === 'Task' ? challenge.name : `${challenge.name} - ${placeToOrdinal(winner.placement)} Place`,
+      });
+    });
+
+    // generate copilot payments
+    const copilotPrizes = find(prizeSets, {type: 'COPILOT'})?.prizes ?? [];
+    if (copilotPrizes.length) {
+      const copilots = challengeResources.copilot;
+
+      if (!copilots?.length) {
+        throw new Error('Task has a copilot prize but no copilot assigned!');
+      }
+
+      copilots.forEach((copilot) => {
+        payments.push({
+          handle: copilot.memberHandle,
+          amount: copilotPrizes[0].value,
+          userId: copilot.memberId.toString(),
+          type: WinningsCategory.COPILOT_PAYMENT,
+        })
+      })
+    }
+
+    // generate reviewer payments
+    const firstPlacePrize = placementPrizes[0].value;
+    const challengeReviewer = find(reviewers, { isMemberReview: true });
+
+    if (challengeReviewer && challengeResources.reviewer) {
+      challengeResources.reviewer?.forEach((reviewer) => {
+        payments.push({
+          handle: reviewer.memberHandle,
+          userId: reviewer.memberId.toString(),
+          amount: Math.round((challengeReviewer.basePayment ?? 0) + ((challengeReviewer.incrementalPayment ?? 0) * challenge.numOfSubmissions) * firstPlacePrize),
+          type: WinningsCategory.REVIEW_BOARD_PAYMENT,
+        })
+      });
+    }
+
+    const totalAmount = payments.reduce((sum, payment) => sum + payment.amount, 0);
+    return payments.map((payment) => ({
+      winnerId: payment.userId.toString(),
+      type: WinningsType.PAYMENT,
+      origin: "Topcoder",
+      category: payment.type,
+      title: challenge.name,
+      description: payment.description || challenge.name,
+      externalId: challenge.id,
+      details: [{
+        totalAmount: payment.amount,
+        grossAmount: payment.amount,
+        installmentNumber: 1,
+        currency: "USD",
+        billingAccount: `${challenge.billing.billingAccountId}`,
+        challengeFee: totalAmount * challenge.billing.markup,
+      }],
+      attributes: {
+        billingAccountId: challenge.billing.billingAccountId,
+        payroll: includes(TGBillingAccounts, challenge.billing.billingAccountId),
+      },
+    }));
+  }
+
+  async generateChallengePayments(challengeId: string, userId: string) {
+    const challenge = await this.getChallenge(challengeId);
+
+    if (!challenge) {
+      throw new Error('Challenge not found!');
+    }
+
+    // TODO: make sure challenge is completed
+    const payments = await this.getChallengePayments(challenge);
+    const totalAmount = payments.reduce((sum, payment) => sum + payment.details[0].totalAmount, 0);
+
+    const baValidation = {
+      challengeId: challenge.id,
+      billingAccountId: +challenge.billing.billingAccountId,
+      markup: challenge.billing.markup,
+      status: challenge.status,
+      totalPrizesInCents: totalAmount * 100,
+    };
+
+    if (challenge.billing?.clientBillingRate != null) {
+      baValidation.markup = challenge.billing.clientBillingRate;
+    }
+
+    await Promise.all(payments.map(p => this.winningsService.createWinningWithPayments(p,userId)));
+
+    this.logger.log("Task Completed. locking consumed budget", baValidation);
+    await this.baService.lockConsumeAmount(baValidation);
+  }
+}

--- a/src/api/challenges/models/challenge.ts
+++ b/src/api/challenges/models/challenge.ts
@@ -1,0 +1,143 @@
+export interface Challenge {
+  id: string;
+  name: string;
+  description: string;
+  descriptionFormat: string;
+  projectId: number;
+  typeId: string;
+  trackId: string;
+  timelineTemplateId: string;
+  currentPhaseNames: string[];
+  wiproAllowed: boolean;
+  tags: string[];
+  groups: string[];
+  submissionStartDate: string;
+  submissionEndDate: string;
+  registrationStartDate: string;
+  registrationEndDate: string;
+  startDate: string;
+  status: string;
+  createdBy: string;
+  updatedBy: string;
+  metadata: MetadataItem[];
+  phases: ChallengePhase[];
+  discussions: Discussion[];
+  events: any[]; // You can replace `any` with the appropriate structure if available
+  prizeSets: PrizeSet[];
+  reviewers: Reviewer[]; // Replace with type if available
+  terms: any[]; // Replace with type if available
+  skills: Skill[];
+  attachments: any[]; // Replace with type if available
+  track: string;
+  type: string;
+  legacy: Legacy;
+  billing: Billing;
+  task: Task;
+  created: string;
+  updated: string;
+  overview: PrizeOverview;
+  winners: Winner[]; // Replace with type if needed
+  numOfSubmissions: number;
+  numOfCheckpointSubmissions: number;
+  numOfRegistrants: number;
+}
+
+export interface MetadataItem {
+  name: string;
+  value: string;
+}
+
+export interface ChallengePhase {
+  id: string;
+  phaseId: string;
+  name: string;
+  description: string;
+  isOpen: boolean;
+  duration: number;
+  scheduledStartDate: string;
+  scheduledEndDate: string;
+  predecessor?: string;
+  constraints: any[]; // Replace with constraint type if needed
+}
+
+export interface Discussion {
+  name: string;
+  type: string;
+  provider: string;
+  id: string;
+  options: any[]; // Replace with option type if needed
+}
+
+export interface PrizeSet {
+  type: string;
+  prizes: Prize[];
+}
+
+export interface Prize {
+  type: string;
+  value: number;
+}
+
+export interface Skill {
+  id: string;
+  name: string;
+  category: SkillCategory;
+}
+
+export interface SkillCategory {
+  id: string;
+  name: string;
+}
+
+export interface Legacy {
+  reviewType: string;
+  confidentialityType: string;
+  directProjectId: number;
+  isTask: boolean;
+  useSchedulingAPI: boolean;
+  pureV5Task: boolean;
+  pureV5: boolean;
+  selfService: boolean;
+}
+
+export interface Billing {
+  billingAccountId: string;
+  markup: number;
+  clientBillingRate?: number;
+}
+
+export interface Task {
+  isTask: boolean;
+  isAssigned: boolean;
+}
+
+export interface PrizeOverview {
+  totalPrizes: number;
+  type: string;
+}
+
+export interface Winner {
+  userId: number;
+  handle: string;
+  placement: number;
+}
+
+export interface Reviewer {
+  scorecardId: string;
+  isMemberReview: boolean;
+  memberReviewerCount?: number;
+  basePayment?: number;
+  incrementalPayment?: number;
+  isAIReviewer: boolean;
+}
+
+export interface ChallengeResource {
+  memberId: string;
+  memberHandle: string;
+  roleId: string;
+}
+
+export interface ResourceRole {
+  id: string;
+  name: string;
+}

--- a/src/api/challenges/models/index.ts
+++ b/src/api/challenges/models/index.ts
@@ -1,0 +1,1 @@
+export * from './challenge';

--- a/src/api/repository/winnings.repo.ts
+++ b/src/api/repository/winnings.repo.ts
@@ -25,7 +25,7 @@ export class WinningsRepository {
 
   constructor(private readonly prisma: PrismaService) {}
 
-  private generateFilterDate(date: DateFilterType) {
+  private generateFilterDate(date?: DateFilterType) {
     let filterDate: object | undefined;
     const currentDay = new Date(new Date().setHours(0, 0, 0, 0));
 
@@ -54,11 +54,11 @@ export class WinningsRepository {
   }
 
   private getWinningsQueryFilters(
-    type: string,
-    status: string,
-    winnerIds: string[] | undefined,
-    externalIds: string[] | undefined,
-    date: DateFilterType,
+    type?: string,
+    status?: string,
+    winnerIds?: string[] | undefined,
+    externalIds?: string[] | undefined,
+    date?: DateFilterType,
   ): Prisma.winningsFindManyArgs['where'] {
     return {
       winner_id: winnerIds
@@ -99,7 +99,7 @@ export class WinningsRepository {
   }
 
   private getOrderByWithWinnerId(
-    sortBy: string,
+    sortBy: string | undefined,
     sortOrder: 'asc' | 'desc',
     externalIds?: boolean,
   ) {
@@ -162,7 +162,7 @@ export class WinningsRepository {
         winnerIds = [searchProps.winnerId];
       } else if (searchProps.winnerIds) {
         winnerIds = [...searchProps.winnerIds];
-      } else if (searchProps.externalIds?.length > 0) {
+      } else if ((searchProps.externalIds?.length ?? 0) > 0) {
         externalIds = searchProps.externalIds;
       }
 
@@ -176,7 +176,7 @@ export class WinningsRepository {
 
       const orderBy = this.getOrderByWithWinnerId(
         searchProps.sortBy,
-        searchProps.sortOrder,
+        searchProps.sortOrder!,
         !winnerIds && !!externalIds?.length,
       );
 
@@ -240,9 +240,9 @@ export class WinningsRepository {
         })),
         pagination: {
           totalItems: count,
-          totalPages: Math.ceil(count / searchProps.limit),
-          pageSize: searchProps.limit,
-          currentPage: Math.ceil(searchProps.offset / searchProps.limit) + 1,
+          totalPages: Math.ceil(count / searchProps.limit!),
+          pageSize: searchProps.limit!,
+          currentPage: Math.ceil(searchProps.offset! / searchProps.limit!) + 1,
         },
       };
       // response.data = winnings as any

--- a/src/api/winnings/winnings.module.ts
+++ b/src/api/winnings/winnings.module.ts
@@ -19,5 +19,8 @@ import { IdentityVerificationRepository } from '../repository/identity-verificat
     PaymentMethodRepository,
     IdentityVerificationRepository,
   ],
+  exports: [
+    WinningsService,
+  ]
 })
 export class WinningsModule {}

--- a/src/config/config.env.ts
+++ b/src/config/config.env.ts
@@ -23,6 +23,9 @@ export class ConfigEnv {
   TOPCODER_API_BASE_URL!: string;
 
   @IsString()
+  TOPCODER_API_V6_BASE_URL!: string;
+
+  @IsString()
   AUTH0_M2M_AUDIENCE!: string;
 
   @IsString()
@@ -110,4 +113,7 @@ export class ConfigEnv {
 
   @IsString()
   SENDGRID_TEMPLATE_ID_OTP_CODE: string = 'd-2d0ab9f6c9cc4efba50080668a9c35c1';
+
+  @IsInt({each: true})
+  TGBillingAccounts = [80000062, 80002800];
 }

--- a/src/dto/challenge.dto.ts
+++ b/src/dto/challenge.dto.ts
@@ -1,0 +1,17 @@
+export const ChallengeStatuses = {
+  New: "New",
+  Active: "Active",
+  Draft: "Draft",
+  Approved: "Approved",
+  Canceled: "Canceled",
+  Completed: "Completed",
+  Deleted: "Deleted",
+  CancelledFailedReview: "Cancelled - Failed Review",
+  CancelledFailedScreening: "Cancelled - Failed Screening",
+  CancelledZeroSubmissions: "Cancelled - Zero Submissions",
+  CancelledWinnerUnresponsive: "Cancelled - Winner Unresponsive",
+  CancelledClientRequest: "Cancelled - Client Request",
+  CancelledRequirementsInfeasible: "Cancelled - Requirements Infeasible",
+  CancelledZeroRegistrations: "Cancelled - Zero Registrations",
+  CancelledPaymentFailed: "Cancelled - Payment Failed",
+};

--- a/src/dto/sort-pagination.dto.ts
+++ b/src/dto/sort-pagination.dto.ts
@@ -34,7 +34,7 @@ export class SortPagination {
   @IsOptional()
   @IsInt()
   @Min(1)
-  limit: number = 10;
+  limit?: number = 10;
 
   @ApiProperty({
     description: 'The offset parameter for pagination',
@@ -43,7 +43,7 @@ export class SortPagination {
   @IsOptional()
   @IsInt()
   @Min(0)
-  offset: number = 0;
+  offset?: number = 0;
 
   @ApiProperty({
     description: 'The sortBy parameter for sorting',
@@ -51,7 +51,7 @@ export class SortPagination {
   })
   @IsOptional()
   @IsIn(OrderBy)
-  sortBy: string;
+  sortBy?: string;
 
   @ApiProperty({
     description: 'The sort order',
@@ -60,5 +60,5 @@ export class SortPagination {
   })
   @IsOptional()
   @IsEnum(SortOrder)
-  sortOrder: SortOrder = SortOrder.ASC;
+  sortOrder?: SortOrder = SortOrder.ASC;
 }

--- a/src/dto/winning.dto.ts
+++ b/src/dto/winning.dto.ts
@@ -128,7 +128,7 @@ export class WinningRequestDto extends SortPagination {
   @IsOptional()
   @IsString()
   @IsNotEmpty()
-  winnerId: string;
+  winnerId?: string;
 
   @ApiProperty({
     description: 'The array of the winner ids',
@@ -139,7 +139,7 @@ export class WinningRequestDto extends SortPagination {
   @ArrayNotEmpty()
   @IsString({ each: true })
   @IsNotEmpty({ each: true })
-  winnerIds: string[];
+  winnerIds?: string[];
 
   @ApiProperty({
     description: 'The array of the external ids',
@@ -150,7 +150,7 @@ export class WinningRequestDto extends SortPagination {
   @ArrayNotEmpty()
   @IsString({ each: true })
   @IsNotEmpty({ each: true })
-  externalIds: string[];
+  externalIds?: string[];
 
   @ApiProperty({
     description: 'The type of winnings category',
@@ -159,7 +159,7 @@ export class WinningRequestDto extends SortPagination {
   })
   @IsOptional()
   @IsEnum(WinningsCategory)
-  type: WinningsCategory;
+  type?: WinningsCategory;
 
   @ApiProperty({
     description: 'The payment status',
@@ -168,7 +168,7 @@ export class WinningRequestDto extends SortPagination {
   })
   @IsOptional()
   @IsEnum(PaymentStatus)
-  status: PaymentStatus;
+  status?: PaymentStatus;
 
   @ApiProperty({
     description: 'The filter date',
@@ -177,7 +177,7 @@ export class WinningRequestDto extends SortPagination {
   })
   @IsOptional()
   @IsEnum(DateFilterType)
-  date: DateFilterType;
+  date?: DateFilterType;
 }
 
 export class WinningCreateRequestDto {

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,8 +69,8 @@ async function bootstrap() {
   });
 
   await app.listen(ENV_CONFIG.PORT ?? 3000);
-  console.log(`Application is running on: ${await app.getUrl()}`);
-  console.log(
+  logger.log(`Application is running on: ${await app.getUrl()}`);
+  logger.log(
     `Swagger docs available at: ${await app.getUrl()}${API_DOCS_URL}`,
   );
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,17 +3,11 @@ import { NestFactory } from '@nestjs/core';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
-import { ApiModule } from './api/api.module';
 import { AppModule } from './app.module';
-import { PaymentProvidersModule } from './api/payment-providers/payment-providers.module';
-import { WebhooksModule } from './api/webhooks/webhooks.module';
 import { ENV_CONFIG } from './config';
-import { AdminModule } from './api/admin/admin.module';
-import { UserModule } from './api/user/user.module';
-import { WalletModule } from './api/wallet/wallet.module';
-import { WinningsModule } from './api/winnings/winnings.module';
-import { WithdrawalModule } from './api/withdrawal/withdrawal.module';
 import { Logger } from 'src/shared/global';
+
+const API_DOCS_URL = `${ENV_CONFIG.API_BASE}/api-docs`;
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
@@ -59,19 +53,8 @@ async function bootstrap() {
       in: 'header',
     })
     .build();
-  const document = SwaggerModule.createDocument(app, config, {
-    include: [
-      ApiModule,
-      AdminModule,
-      UserModule,
-      WinningsModule,
-      WithdrawalModule,
-      WalletModule,
-      PaymentProvidersModule,
-      WebhooksModule,
-    ],
-  });
-  SwaggerModule.setup('/v5/finance/api-docs', app, document);
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup(API_DOCS_URL, app, document);
 
   // Add an event handler to log uncaught promise rejections and prevent the server from crashing
   process.on('unhandledRejection', (reason, promise) => {
@@ -86,6 +69,10 @@ async function bootstrap() {
   });
 
   await app.listen(ENV_CONFIG.PORT ?? 3000);
+  console.log(`Application is running on: ${await app.getUrl()}`);
+  console.log(
+    `Swagger docs available at: ${await app.getUrl()}${API_DOCS_URL}`,
+  );
 }
 
 void bootstrap();

--- a/src/shared/topcoder/billing-accounts.service.ts
+++ b/src/shared/topcoder/billing-accounts.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { isNumber, includes } from 'lodash';
 import { ENV_CONFIG } from 'src/config';
+import { ChallengeStatuses } from 'src/dto/challenge.dto';
 import { TopcoderM2MService } from './topcoder-m2m.service';
 
 const {
@@ -29,24 +30,6 @@ export interface BAValidation {
   totalPrizesInCents: number;
 }
 
-export const ChallengeStatuses = {
-  New: "New",
-  Active: "Active",
-  Draft: "Draft",
-  Approved: "Approved",
-  Canceled: "Canceled",
-  Completed: "Completed",
-  Deleted: "Deleted",
-  CancelledFailedReview: "Cancelled - Failed Review",
-  CancelledFailedScreening: "Cancelled - Failed Screening",
-  CancelledZeroSubmissions: "Cancelled - Zero Submissions",
-  CancelledWinnerUnresponsive: "Cancelled - Winner Unresponsive",
-  CancelledClientRequest: "Cancelled - Client Request",
-  CancelledRequirementsInfeasible: "Cancelled - Requirements Infeasible",
-  CancelledZeroRegistrations: "Cancelled - Zero Registrations",
-  CancelledPaymentFailed: "Cancelled - Payment Failed",
-};
-
 @Injectable()
 export class BillingAccountsService {
   private readonly logger = new Logger(BillingAccountsService.name);
@@ -57,13 +40,6 @@ export class BillingAccountsService {
     this.logger.log("BA validation lock amount:", billingAccountId, dto);
 
     try {
-      console.log('Calling ',
-        `${TOPCODER_API_V6_BASE_URL}/billing-accounts/${billingAccountId}/lock-amount`,
-        {
-          method: 'PATCH',
-          body: JSON.stringify({ param: dto }),
-        }
-      )
       return await this.m2MService.m2mFetch(
         `${TOPCODER_API_V6_BASE_URL}/billing-accounts/${billingAccountId}/lock-amount`,
         {
@@ -84,13 +60,6 @@ export class BillingAccountsService {
     this.logger.log("BA validation consume amount:", billingAccountId, dto);
 
     try {
-      console.log('Calling ',
-        `${TOPCODER_API_V6_BASE_URL}/billing-accounts/${billingAccountId}/consume-amount`,
-        {
-          method: 'PATCH',
-          body: JSON.stringify({ param: dto }),
-        }
-      )
       return await this.m2MService.m2mFetch(
         `${TOPCODER_API_V6_BASE_URL}/billing-accounts/${billingAccountId}/consume-amount`,
         {

--- a/src/shared/topcoder/billing-accounts.service.ts
+++ b/src/shared/topcoder/billing-accounts.service.ts
@@ -1,0 +1,171 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { isNumber, includes } from 'lodash';
+import { ENV_CONFIG } from 'src/config';
+import { TopcoderM2MService } from './topcoder-m2m.service';
+
+const {
+  TOPCODER_API_V6_BASE_URL,
+  TGBillingAccounts,
+} = ENV_CONFIG;
+
+
+interface LockAmountDTO {
+  challengeId: string;
+  lockAmount: number;
+}
+interface ConsumeAmountDTO {
+  challengeId: string;
+  consumeAmount: number;
+  markup?: number;
+}
+
+export interface BAValidation {
+  challengeId?: string;
+  billingAccountId?: number;
+  markup?: number;
+  prevStatus?: string;
+  status?: string;
+  prevTotalPrizesInCents?: number;
+  totalPrizesInCents: number;
+}
+
+export const ChallengeStatuses = {
+  New: "New",
+  Active: "Active",
+  Draft: "Draft",
+  Approved: "Approved",
+  Canceled: "Canceled",
+  Completed: "Completed",
+  Deleted: "Deleted",
+  CancelledFailedReview: "Cancelled - Failed Review",
+  CancelledFailedScreening: "Cancelled - Failed Screening",
+  CancelledZeroSubmissions: "Cancelled - Zero Submissions",
+  CancelledWinnerUnresponsive: "Cancelled - Winner Unresponsive",
+  CancelledClientRequest: "Cancelled - Client Request",
+  CancelledRequirementsInfeasible: "Cancelled - Requirements Infeasible",
+  CancelledZeroRegistrations: "Cancelled - Zero Registrations",
+  CancelledPaymentFailed: "Cancelled - Payment Failed",
+};
+
+@Injectable()
+export class BillingAccountsService {
+  private readonly logger = new Logger(BillingAccountsService.name);
+
+  constructor(private readonly m2MService: TopcoderM2MService) {}
+
+  async lockAmount(billingAccountId: number, dto: LockAmountDTO) {
+    this.logger.log("BA validation lock amount:", billingAccountId, dto);
+
+    try {
+      console.log('Calling ',
+        `${TOPCODER_API_V6_BASE_URL}/billing-accounts/${billingAccountId}/lock-amount`,
+        {
+          method: 'PATCH',
+          body: JSON.stringify({ param: dto }),
+        }
+      )
+      return await this.m2MService.m2mFetch(
+        `${TOPCODER_API_V6_BASE_URL}/billing-accounts/${billingAccountId}/lock-amount`,
+        {
+          method: 'PATCH',
+          body: JSON.stringify({ param: dto }),
+        },
+      );
+    } catch (err: any) {
+      this.logger.error(err.response?.data?.result?.content ?? "Failed to lock challenge amount");
+      throw new Error(
+        `Budget Error: Requested amount $${dto.lockAmount} exceeds available budget for Billing Account #${billingAccountId}.
+        Please contact the Topcoder Project Manager for further assistance.`
+      );
+    }
+  }
+
+  async consumeAmount(billingAccountId: number, dto: ConsumeAmountDTO) {
+    this.logger.log("BA validation consume amount:", billingAccountId, dto);
+
+    try {
+      console.log('Calling ',
+        `${TOPCODER_API_V6_BASE_URL}/billing-accounts/${billingAccountId}/consume-amount`,
+        {
+          method: 'PATCH',
+          body: JSON.stringify({ param: dto }),
+        }
+      )
+      return await this.m2MService.m2mFetch(
+        `${TOPCODER_API_V6_BASE_URL}/billing-accounts/${billingAccountId}/consume-amount`,
+        {
+          method: 'PATCH',
+          body: JSON.stringify({ param: dto }),
+        },
+      );
+    } catch (err: any) {
+      this.logger.error(err.response?.data?.result?.content ?? "Failed to consume challenge amount", err);
+      throw new Error("Failed to consume challenge amount");
+    }
+  }
+
+  async lockConsumeAmount(baValidation: BAValidation, rollback: boolean = false): Promise<void> {
+    const billingAccountId = baValidation.billingAccountId ? +baValidation.billingAccountId : undefined;
+    if (!isNumber(billingAccountId)) {
+      this.logger.warn("Challenge doesn't have billing account id:", baValidation);
+      return;
+    }
+    if (includes(TGBillingAccounts, billingAccountId)) {
+      this.logger.info("Ignore BA validation for Topgear account:", billingAccountId);
+      return;
+    }
+
+    this.logger.log("BA validation:", baValidation);
+
+    const status = baValidation.status?.toLowerCase();
+    if (
+      status === ChallengeStatuses.Active.toLowerCase() ||
+      status === ChallengeStatuses.Approved.toLowerCase()
+    ) {
+      // Update lock amount
+      const currAmount = baValidation.totalPrizesInCents / 100;
+      const prevAmount = (baValidation.prevTotalPrizesInCents ?? 0) / 100;
+
+      await this.lockAmount(billingAccountId!, {
+        challengeId: baValidation.challengeId!,
+        lockAmount: (rollback ? prevAmount : currAmount) * (1 + baValidation.markup!),
+      });
+    } else if (status === ChallengeStatuses.Completed.toLowerCase()) {
+      // Note an already completed challenge could still be updated with prizes
+      const currAmount = baValidation.totalPrizesInCents / 100;
+      const prevAmount = baValidation.prevStatus === ChallengeStatuses.Completed ? (baValidation.prevTotalPrizesInCents ?? 0) / 100 : 0;
+
+      if (currAmount !== prevAmount) {
+        await this.consumeAmount(billingAccountId!, {
+          challengeId: baValidation.challengeId!,
+          consumeAmount: (rollback ? prevAmount : currAmount) * (1 + baValidation.markup!),
+          markup: baValidation.markup,
+        });
+      }
+    } else if ([
+      ChallengeStatuses.Deleted,
+      ChallengeStatuses.Canceled,
+      ChallengeStatuses.CancelledFailedReview,
+      ChallengeStatuses.CancelledFailedScreening,
+      ChallengeStatuses.CancelledZeroSubmissions,
+      ChallengeStatuses.CancelledWinnerUnresponsive,
+      ChallengeStatuses.CancelledClientRequest,
+      ChallengeStatuses.CancelledRequirementsInfeasible,
+      ChallengeStatuses.CancelledZeroRegistrations,
+      ChallengeStatuses.CancelledPaymentFailed
+    ].some(t => t.toLowerCase() === status)) {
+      if(baValidation.prevStatus?.toLowerCase() === ChallengeStatuses.Active.toLowerCase()) {
+        // Challenge canceled, unlock previous locked amount
+        const currAmount = 0;
+        const prevAmount = (baValidation.prevTotalPrizesInCents ?? 0) / 100;
+
+        if (currAmount !== prevAmount) {
+          await this.lockAmount(billingAccountId!, {
+            challengeId: baValidation.challengeId!,
+            lockAmount: rollback ? prevAmount : 0,
+          });
+        }
+      }
+    }
+  }
+}

--- a/src/shared/topcoder/challenges.service.ts
+++ b/src/shared/topcoder/challenges.service.ts
@@ -46,16 +46,6 @@ export class TopcoderChallengesService {
     payoutData: WithdrawUpdateData | AdminPaymentUpdateData,
   ) {
     const requestData = mapStatus(payoutData);
-
-    let m2mToken: string | undefined;
-    try {
-      m2mToken = await this.m2MService.getToken();
-    } catch (e) {
-      this.logger.error(
-        'Failed to fetch m2m token for fetching member details!',
-        e.message ?? e,
-      );
-    }
     const requestUrl = `${TOPCODER_API_BASE_URL}/challenges/${challengeId}/legacy-payment`;
 
     this.logger.debug(
@@ -63,26 +53,16 @@ export class TopcoderChallengesService {
     );
 
     try {
-      const response = await fetch(requestUrl, {
+      const response = await this.m2MService.m2mFetch(requestUrl, {
         method: 'PATCH',
         body: JSON.stringify(requestData),
-        headers: {
-          Authorization: `Bearer ${m2mToken}`,
-          'Content-Type': 'application/json',
-        },
       });
 
-      const jsonResponse: { [key: string]: string } = await response.json();
-
-      if (response.status > 299) {
-        throw new Error(jsonResponse.message ?? JSON.stringify(jsonResponse));
-      }
-
       this.logger.debug(
-        `Response from updating legacy payment for challenge ${challengeId}: ${JSON.stringify(jsonResponse, null, 2)}`,
+        `Response from updating legacy payment for challenge ${challengeId}: ${JSON.stringify(response, null, 2)}`,
       );
 
-      return jsonResponse;
+      return response;
     } catch (e) {
       this.logger.error(
         `Failed to update legacy payment for challenge ${challengeId}! Error: ${e?.message ?? e}`,

--- a/src/shared/topcoder/topcoder-m2m.service.ts
+++ b/src/shared/topcoder/topcoder-m2m.service.ts
@@ -78,7 +78,6 @@ export class TopcoderM2MService {
     const response = await fetch(url, finalOptions);
 
     if (!response.ok) {
-      this.logger.log(await response.text());
       // Optional: You could throw a custom error here
       throw new Error(`HTTP error! Status: ${response.status}`);
     }

--- a/src/shared/topcoder/topcoder-m2m.service.ts
+++ b/src/shared/topcoder/topcoder-m2m.service.ts
@@ -33,6 +33,7 @@ export class TopcoderM2MService {
           client_secret: ENV_CONFIG.AUTH0_M2M_SECRET,
           audience: ENV_CONFIG.AUTH0_M2M_AUDIENCE,
           grant_type: ENV_CONFIG.AUTH0_M2M_GRANT_TYPE,
+          // fresh_token: true,
         }),
       });
 
@@ -44,5 +45,52 @@ export class TopcoderM2MService {
       this.logger.error('Failed fetching TC M2M Token!', error);
       return undefined;
     }
+  }
+
+  async m2mFetch<T = unknown>(url: string | URL, options = {} as RequestInit) {
+    let m2mToken: string | undefined;
+    try {
+      m2mToken = await this.getToken();
+    } catch (e) {
+      this.logger.error(
+        'Failed to fetch m2m token!',
+        e.message ?? e,
+      );
+    }
+
+    if (!m2mToken) {
+      throw new Error('Failed to fetch m2m token for m2m call!')
+    }
+
+    // Initialize headers, ensuring Authorization is added
+    const headers = new Headers(options.headers || {});
+    headers.set('Authorization', `Bearer ${m2mToken}`);
+
+    if (!headers.get('Content-Type')) {
+      headers.set('Content-Type', 'application/json');
+    }
+
+    const finalOptions: RequestInit = {
+      ...options,
+      headers,
+    };
+
+    const response = await fetch(url, finalOptions);
+
+    if (!response.ok) {
+      this.logger.log(await response.text());
+      // Optional: You could throw a custom error here
+      throw new Error(`HTTP error! Status: ${response.status}`);
+    }
+
+    const contentType = response.headers.get('content-type');
+
+    // Try to parse JSON if content-type is application/json
+    if (contentType && contentType.includes('application/json')) {
+      return response.json() as Promise<T>;
+    }
+
+    // If not JSON, return text
+    return response.text() as unknown as T;
   }
 }

--- a/src/shared/topcoder/topcoder.module.ts
+++ b/src/shared/topcoder/topcoder.module.ts
@@ -4,6 +4,7 @@ import { TopcoderM2MService } from './topcoder-m2m.service';
 import { TopcoderChallengesService } from './challenges.service';
 import { TopcoderBusService } from './bus.service';
 import { TopcoderEmailService } from './tc-email.service';
+import { BillingAccountsService } from './billing-accounts.service';
 
 @Module({
   providers: [
@@ -12,12 +13,15 @@ import { TopcoderEmailService } from './tc-email.service';
     TopcoderM2MService,
     TopcoderBusService,
     TopcoderEmailService,
+    BillingAccountsService,
   ],
   exports: [
     TopcoderChallengesService,
     TopcoderMembersService,
+    TopcoderM2MService,
     TopcoderBusService,
     TopcoderEmailService,
+    BillingAccountsService,
   ],
 })
 export class TopcoderModule {}


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PM-1112 - Add endpoint to apply payments for the end of a challenge

- get the winners from the challenge object (or DB): used api calls to challenge api, reasoning being to keep the same data format and not re-define models
- Get the payment information from the challenge object
- Figure out the payments for each place / winner
- Figure out the payment for each reviewer
- Figure out the payment for each copilot (usually only 1)
- Get the billing account ID and markup from the challenge. Apply the markup to calculate the challenge fee for each payment (already implemented)
- Calculate the release date for the payment
- Add the payment records to the DB
- Mark the total amount paid for the challenge against the billing account value, to ensure that we have an accurate record of what’s consumed (see consumed DAO in PM-1113)


NOTE: I created a new endpoint rather than updating the `POST /winnings`. The reason is scope separation. Winnings is handling creating & storing user payments (no matter how they got that win/payment). 
This new endpoint does a lot more: and is really specific to challenges. After it calculates the data, it still calls the winnings service to store the payments.

NOTE2: this is more of a work in progress I'd say. we still have to figure out:
- design checkpoint prizes (for both reviewers & participants)
- iterative reviewer (F2F)