### PR TITLE
PM-4623: validate wallet-admin engagement payment details flow

### DIFF
--- a/src/api/winnings/winnings.service.ts
+++ b/src/api/winnings/winnings.service.ts
@@ -53,22 +53,24 @@ export class WinningsService {
    * Builds the persisted winning attributes object.
    * @param attributes Arbitrary attributes supplied by the client.
    * @param hoursWorked Optional engagement-payment hours to persist.
-   * @returns The normalized attributes object, or `null` when empty.
+   * @returns The normalized attributes object, or `undefined` when empty.
    */
   private buildWinningAttributes(
-    attributes: object | undefined,
+    attributes: Record<string, unknown> | undefined,
     hoursWorked?: number,
-  ): Record<string, unknown> | null {
-    const normalizedAttributes =
-      attributes && typeof attributes === 'object' ? { ...attributes } : {};
+  ): Prisma.InputJsonValue | undefined {
+    const normalizedAttributes: Record<string, unknown> =
+      attributes && typeof attributes === 'object' && !Array.isArray(attributes)
+        ? { ...attributes }
+        : {};
 
     if (hoursWorked !== undefined) {
       normalizedAttributes.hoursWorked = hoursWorked;
     }
 
     return Object.keys(normalizedAttributes).length
-      ? normalizedAttributes
-      : null;
+      ? (normalizedAttributes as Prisma.InputJsonObject)
+      : undefined;
   }
 
   private async sendSetupEmailNotification(userId: string, amount: number) {
@@ -257,7 +259,7 @@ export class WinningsService {
         description: body.description,
         external_id: body.externalId,
         attributes: this.buildWinningAttributes(
-          body.attributes,
+          body.attributes as Record<string, unknown> | undefined,
           body.hoursWorked,
         ),
         created_by: userId,
@@ -279,7 +281,10 @@ export class WinningsService {
 
       this.logger.debug('Constructed winning model', { winningModel });
 
-      const payrollPayment = (body.attributes || {})['payroll'] === true;
+      const requestAttributes = body.attributes as
+        | Record<string, unknown>
+        | undefined;
+      const payrollPayment = requestAttributes?.payroll === true;
       const isPointsAward = body.category === WinningsCategory.POINTS_AWARD;
       const requestedStatus = body.status as payment_status | undefined;
 


### PR DESCRIPTION
What was broken
PM-4623's wallet-admin engagement payment flow was already implemented in the current dev lineage, but tc-finance-api validation could not complete because winnings creation no longer satisfied Prisma's JSON input typing after the hours-worked attribute support was added.

Root cause
The winnings attribute helper used broad object/null typing, while the create path now needs Prisma-compatible JSON input values and a typed payroll attribute lookup.

What was changed
Updated the winnings attribute normalization helper to return Prisma-compatible JSON input, return undefined instead of null when no attributes are present, and narrowed the create-path attribute handling so the hours-worked and payroll lookups remain type-safe without changing runtime behavior.

Any added/updated tests
No test files were changed. Re-ran the existing platform-ui and tc-finance-api test suites, plus the required lint/build commands.