### PR TITLE
PM-4623: fall back to engagement lookup for payment details

### DIFF
--- a/src/api/admin/admin.service.spec.ts
+++ b/src/api/admin/admin.service.spec.ts
@@ -52,6 +52,7 @@ describe('AdminService', () => {
   };
   let topcoderEngagementsService: {
     getAssignmentContextById: jest.Mock;
+    getEngagementById: jest.Mock;
   };
 
   beforeEach(() => {
@@ -67,6 +68,7 @@ describe('AdminService', () => {
     };
     topcoderEngagementsService = {
       getAssignmentContextById: jest.fn(),
+      getEngagementById: jest.fn(),
     };
 
     service = new AdminService(
@@ -161,6 +163,105 @@ describe('AdminService', () => {
         remarks: 'Weekly support work.',
       },
     });
+  });
+
+  it('falls back to the engagement lookup when external_id stores an engagement id', async () => {
+    prisma.winnings.findFirst.mockResolvedValue({
+      winning_id: 'winning-1',
+      winner_id: '123456',
+      category: 'ENGAGEMENT_PAYMENT',
+      external_id: 'engagement-1',
+      attributes: {
+        hoursWorked: 10,
+        remarks: 'Covered support hours.',
+      },
+    });
+    topcoderEngagementsService.getAssignmentContextById.mockRejectedValue(
+      new Error('assignment not found'),
+    );
+    topcoderEngagementsService.getEngagementById.mockResolvedValue({
+      assignments: [
+        {
+          durationMonths: 6,
+          id: 'assignment-1',
+          memberId: '123456',
+          otherRemarks: 'Working EST overlap.',
+          ratePerHour: '82.50',
+          standardHoursPerWeek: 35,
+          startDate: '2026-01-15T00:00:00.000Z',
+        },
+      ],
+      id: 'engagement-1',
+      projectId: 'project-1',
+      projectName: 'Platform Modernization',
+      title: 'Senior Frontend Engineer',
+    });
+
+    const result = await service.getWinningPaymentDetails(
+      'winning-1',
+      '123456',
+      ['Payment Admin'],
+    );
+
+    expect(
+      topcoderEngagementsService.getAssignmentContextById,
+    ).toHaveBeenCalledWith('engagement-1');
+    expect(topcoderEngagementsService.getEngagementById).toHaveBeenCalledWith(
+      'engagement-1',
+    );
+    expect(result.data).toEqual({
+      engagementDetails: {
+        assignmentId: 'assignment-1',
+        billingStartDate: new Date('2026-01-15T00:00:00.000Z'),
+        durationMonths: 6,
+        engagementId: 'engagement-1',
+        engagementTitle: 'Senior Frontend Engineer',
+        otherRemarks: 'Working EST overlap.',
+        projectId: 'project-1',
+        projectName: 'Platform Modernization',
+        ratePerHour: '82.50',
+        standardHoursPerWeek: 35,
+      },
+      workLog: {
+        hoursWorked: 10,
+        remarks: 'Covered support hours.',
+      },
+    });
+  });
+
+  it('prefers a numeric assignmentId stored in winning attributes', async () => {
+    prisma.winnings.findFirst.mockResolvedValue({
+      winning_id: 'winning-1',
+      category: 'ENGAGEMENT_PAYMENT',
+      external_id: 'engagement-1',
+      attributes: {
+        assignmentId: 98765,
+        hoursWorked: 12,
+        remarks: 'Weekly support work.',
+      },
+    });
+    topcoderEngagementsService.getAssignmentContextById.mockResolvedValue({
+      assignmentId: '98765',
+      engagementId: 'engagement-1',
+      engagementTitle: 'Senior Frontend Engineer',
+      projectId: 'project-1',
+      projectName: 'Platform Modernization',
+      ratePerHour: '75.50',
+      standardHoursPerWeek: 40,
+      startDate: '2026-02-12T00:00:00.000Z',
+      status: 'ACTIVE',
+      memberHandle: 'tester',
+      memberId: '123456',
+    });
+
+    await service.getWinningPaymentDetails('winning-1', '123456', [
+      'Payment Admin',
+    ]);
+
+    expect(
+      topcoderEngagementsService.getAssignmentContextById,
+    ).toHaveBeenCalledWith('98765');
+    expect(topcoderEngagementsService.getEngagementById).not.toHaveBeenCalled();
   });
 
   it('throws when the winning does not exist', async () => {

--- a/src/api/admin/admin.service.ts
+++ b/src/api/admin/admin.service.ts
@@ -17,7 +17,11 @@ import { WinningAuditDto, AuditPayoutDto } from './dto/audit.dto';
 import { WinningUpdateRequestDto } from './dto/winnings.dto';
 import { Logger } from 'src/shared/global';
 import { BillingAccountsService } from 'src/shared/topcoder/billing-accounts.service';
-import { TopcoderEngagementsService } from 'src/shared/topcoder/engagements.service';
+import {
+  TopcoderEngagementAssignment,
+  TopcoderEngagementDetails,
+  TopcoderEngagementsService,
+} from 'src/shared/topcoder/engagements.service';
 import { WinningPaymentDetailsDto } from './dto/payment-details.dto';
 
 /**
@@ -100,11 +104,133 @@ export class AdminService {
   private getWinningAssignmentId(
     winning: Awaited<ReturnType<AdminService['getWinningById']>>,
   ): string | undefined {
-    return (
-      this.getStringAttribute(winning?.attributes ?? null, 'assignmentId') ??
-      winning?.external_id ??
-      undefined
-    );
+    if (
+      !winning?.attributes ||
+      typeof winning.attributes !== 'object' ||
+      Array.isArray(winning.attributes)
+    ) {
+      return undefined;
+    }
+
+    const assignmentId = (winning.attributes as Record<string, unknown>)
+      .assignmentId;
+
+    if (typeof assignmentId === 'string') {
+      const normalizedAssignmentId = assignmentId.trim();
+      return normalizedAssignmentId || undefined;
+    }
+
+    if (typeof assignmentId === 'number' && Number.isFinite(assignmentId)) {
+      return String(assignmentId);
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Finds the engagement assignment that best matches the current winning.
+   *
+   * @param assignments assignments returned by the engagements API.
+   * @param winnerId Topcoder member identifier stored on the winning.
+   * @param assignmentId optional assignment identifier captured on the winning.
+   * @returns the matched assignment, or the only assignment when the engagement
+   * has a single assignee.
+   * @throws This helper does not throw.
+   */
+  private findMatchingEngagementAssignment(
+    assignments: TopcoderEngagementAssignment[] | null | undefined,
+    winnerId: string,
+    assignmentId?: string,
+  ): TopcoderEngagementAssignment | undefined {
+    if (!Array.isArray(assignments) || assignments.length === 0) {
+      return undefined;
+    }
+
+    if (assignmentId) {
+      const assignmentMatch = assignments.find((item) => {
+        if (item.id === undefined || item.id === null) {
+          return false;
+        }
+
+        return String(item.id).trim() === assignmentId;
+      });
+
+      if (assignmentMatch) {
+        return assignmentMatch;
+      }
+    }
+
+    const winnerMatch = assignments.find((item) => {
+      if (item.memberId === undefined || item.memberId === null) {
+        return false;
+      }
+
+      return String(item.memberId).trim() === winnerId;
+    });
+
+    if (winnerMatch) {
+      return winnerMatch;
+    }
+
+    return assignments.length === 1 ? assignments[0] : undefined;
+  }
+
+  /**
+   * Builds wallet-admin engagement details from an engagement record.
+   *
+   * @param engagement engagement payload returned by the engagements API.
+   * @param assignment matched assignment for the winning, when available.
+   * @param assignmentId optional assignment identifier captured on the winning.
+   * @returns engagement details shaped for the payment details response.
+   * @throws This helper does not throw.
+   */
+  private buildEngagementDetailsFromEngagement(
+    engagement: TopcoderEngagementDetails,
+    assignment?: TopcoderEngagementAssignment,
+    assignmentId?: string,
+  ): WinningPaymentDetailsDto['engagementDetails'] {
+    const durationMonths =
+      assignment?.durationMonths !== undefined &&
+      assignment.durationMonths !== null
+        ? Number(assignment.durationMonths)
+        : undefined;
+    const standardHoursPerWeek =
+      assignment?.standardHoursPerWeek !== undefined &&
+      assignment.standardHoursPerWeek !== null
+        ? Number(assignment.standardHoursPerWeek)
+        : undefined;
+    const projectId = engagement.projectId ?? engagement.project?.id;
+    const projectName =
+      (engagement.projectName ?? engagement.project?.name)?.trim() ?? undefined;
+    const engagementId =
+      engagement.id !== undefined && engagement.id !== null
+        ? String(engagement.id).trim() || undefined
+        : undefined;
+
+    return {
+      assignmentId:
+        assignment?.id !== undefined && assignment.id !== null
+          ? String(assignment.id).trim() || assignmentId
+          : assignmentId,
+      engagementId,
+      projectId:
+        projectId !== undefined && projectId !== null
+          ? String(projectId).trim() || undefined
+          : undefined,
+      projectName,
+      engagementTitle: engagement.title?.trim() ?? undefined,
+      billingStartDate: assignment?.startDate
+        ? new Date(assignment.startDate)
+        : undefined,
+      durationMonths: Number.isFinite(durationMonths)
+        ? durationMonths
+        : undefined,
+      ratePerHour: assignment?.ratePerHour?.trim() ?? undefined,
+      standardHoursPerWeek: Number.isFinite(standardHoursPerWeek)
+        ? standardHoursPerWeek
+        : undefined,
+      otherRemarks: assignment?.otherRemarks?.trim() ?? undefined,
+    };
   }
 
   private getPaymentsByWinningsId(winningsId: string, paymentId?: string) {
@@ -572,36 +698,70 @@ export class AdminService {
     };
 
     const assignmentId = this.getWinningAssignmentId(winning);
+    const externalId =
+      typeof winning.external_id === 'string'
+        ? winning.external_id.trim() || undefined
+        : undefined;
+    const assignmentLookupId = assignmentId ?? externalId;
     const isEngagementPayment = winning.category === 'ENGAGEMENT_PAYMENT';
 
-    if (!isEngagementPayment || !assignmentId) {
+    if (!isEngagementPayment) {
+      return result;
+    }
+
+    if (assignmentLookupId) {
+      try {
+        const assignmentContext =
+          await this.topcoderEngagementsService.getAssignmentContextById(
+            assignmentLookupId,
+          );
+
+        result.data.engagementDetails = {
+          assignmentId: assignmentContext.assignmentId,
+          engagementId: assignmentContext.engagementId,
+          projectId: assignmentContext.projectId,
+          projectName: assignmentContext.projectName ?? undefined,
+          engagementTitle: assignmentContext.engagementTitle,
+          billingStartDate: assignmentContext.startDate
+            ? new Date(assignmentContext.startDate)
+            : undefined,
+          durationMonths: assignmentContext.durationMonths ?? undefined,
+          ratePerHour: assignmentContext.ratePerHour ?? undefined,
+          standardHoursPerWeek:
+            assignmentContext.standardHoursPerWeek ?? undefined,
+          otherRemarks: assignmentContext.otherRemarks ?? undefined,
+        };
+
+        return result;
+      } catch (error) {
+        this.logger.warn(
+          `Failed to enrich winning ${winningsId} with assignment context`,
+          error instanceof Error ? error.message : error,
+        );
+      }
+    }
+
+    if (!externalId) {
       return result;
     }
 
     try {
-      const assignmentContext =
-        await this.topcoderEngagementsService.getAssignmentContextById(
-          assignmentId,
-        );
+      const engagement =
+        await this.topcoderEngagementsService.getEngagementById(externalId);
+      const assignment = this.findMatchingEngagementAssignment(
+        engagement.assignments,
+        winning.winner_id,
+        assignmentId,
+      );
 
-      result.data.engagementDetails = {
-        assignmentId: assignmentContext.assignmentId,
-        engagementId: assignmentContext.engagementId,
-        projectId: assignmentContext.projectId,
-        projectName: assignmentContext.projectName ?? undefined,
-        engagementTitle: assignmentContext.engagementTitle,
-        billingStartDate: assignmentContext.startDate
-          ? new Date(assignmentContext.startDate)
-          : undefined,
-        durationMonths: assignmentContext.durationMonths ?? undefined,
-        ratePerHour: assignmentContext.ratePerHour ?? undefined,
-        standardHoursPerWeek:
-          assignmentContext.standardHoursPerWeek ?? undefined,
-        otherRemarks: assignmentContext.otherRemarks ?? undefined,
-      };
+      result.data.engagementDetails = this.buildEngagementDetailsFromEngagement(
+        engagement,
+        assignment,
+        assignmentId,
+      );
     } catch (error) {
       this.logger.warn(
-        `Failed to enrich winning ${winningsId} with engagement context`,
+        `Failed to enrich winning ${winningsId} with engagement details`,
         error instanceof Error ? error.message : error,
       );
     }

--- a/src/shared/topcoder/engagements.service.ts
+++ b/src/shared/topcoder/engagements.service.ts
@@ -24,6 +24,32 @@ export interface TopcoderAssignmentContext {
   status: string;
 }
 
+export interface TopcoderEngagementAssignment {
+  agreementRate?: string | null;
+  durationMonths?: number | string | null;
+  endDate?: string | null;
+  engagementId?: string | number | null;
+  id: string | number;
+  memberHandle?: string | null;
+  memberId?: string | number | null;
+  otherRemarks?: string | null;
+  ratePerHour?: string | null;
+  startDate?: string | null;
+  standardHoursPerWeek?: number | string | null;
+}
+
+export interface TopcoderEngagementDetails {
+  assignments?: TopcoderEngagementAssignment[] | null;
+  id: string | number;
+  project?: {
+    id?: string | number | null;
+    name?: string | null;
+  } | null;
+  projectId?: string | number | null;
+  projectName?: string | null;
+  title?: string | null;
+}
+
 @Injectable()
 export class TopcoderEngagementsService {
   private readonly logger = new Logger(TopcoderEngagementsService.name);
@@ -49,6 +75,33 @@ export class TopcoderEngagementsService {
     } catch (error) {
       this.logger.error(
         `Failed to fetch engagement assignment context for ${assignmentId}`,
+        error instanceof Error ? error.message : error,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Retrieves an engagement record, including assignment metadata, from the
+   * engagements API.
+   *
+   * @param engagementId engagement identifier stored on the winning external ID.
+   * @returns engagement details with assignments used to hydrate wallet-admin
+   * payment details.
+   * @throws {Error} When the engagements API request fails.
+   */
+  async getEngagementById(
+    engagementId: string,
+  ): Promise<TopcoderEngagementDetails> {
+    const requestUrl = `${TC_API_BASE}/engagements/engagements/${engagementId}`;
+
+    try {
+      return await this.m2MService.m2mFetch<TopcoderEngagementDetails>(
+        requestUrl,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to fetch engagement details for ${engagementId}`,
         error instanceof Error ? error.message : error,
       );
       throw error;


### PR DESCRIPTION
What was broken
Wallet-admin payment details only enriched engagement payments when the winning could be resolved through the assignment context endpoint. Payments whose `external_id` stored an engagement id instead of an assignment id showed work-log data but missed the engagement details needed to build the Work Manager assignee link and assignment context section.

Root cause
The admin payment-details flow treated the stored identifier as an assignment id and stopped after the assignment-context lookup failed, even though some winnings only retained the parent engagement id. Numeric assignment ids in winning attributes also needed to be normalized before lookup.

What was changed
Added typed engagement API models and a direct engagement lookup helper in the Topcoder engagements client. Updated the admin payment-details service to normalize numeric assignment ids, try the assignment-context endpoint first, and then fall back to loading the engagement and matching the correct assignment by assignment id or winner id when needed.

Any added/updated tests
Extended the admin service spec with regressions for the engagement-id fallback path and for numeric assignment ids stored in winning attributes.
