### PR TITLE
PM-4822: add Payment Creator to wallet export CSV

### DIFF
--- a/src/api/admin/admin.controller.spec.ts
+++ b/src/api/admin/admin.controller.spec.ts
@@ -1,0 +1,194 @@
+jest.mock('./admin.service', () => ({
+  AdminService: class {},
+}));
+
+jest.mock('../repository/winnings.repo', () => ({
+  WinningsRepository: class {},
+}));
+
+jest.mock('src/shared/topcoder/members.service', () => ({
+  TopcoderMembersService: class {},
+}));
+
+jest.mock('src/shared/access-control', () => ({
+  AccessControlService: class {},
+}));
+
+import { AdminController } from './admin.controller';
+import { PaymentStatus } from 'src/dto/payment.dto';
+import {
+  WinningRequestDto,
+  WinningsCategory,
+  WinningsType,
+} from 'src/dto/winning.dto';
+
+describe('AdminController', () => {
+  let controller: AdminController;
+  let winningsRepo: {
+    searchWinnings: jest.Mock;
+  };
+  let tcMembersService: {
+    getHandlesByUserIds: jest.Mock;
+  };
+  let accessControlService: {
+    applyFilters: jest.Mock;
+  };
+
+  beforeEach(() => {
+    winningsRepo = {
+      searchWinnings: jest.fn(),
+    };
+    tcMembersService = {
+      getHandlesByUserIds: jest.fn(),
+    };
+    accessControlService = {
+      applyFilters: jest.fn(),
+    };
+
+    controller = new AdminController(
+      {} as any,
+      winningsRepo as any,
+      tcMembersService as any,
+      accessControlService as any,
+    );
+  });
+
+  it('includes the payment creator column for engagement payment exports only', async () => {
+    accessControlService.applyFilters.mockResolvedValue({
+      type: WinningsType.PAYMENT,
+    } satisfies WinningRequestDto);
+    winningsRepo.searchWinnings
+      .mockResolvedValueOnce({
+        data: {
+          winnings: [
+            {
+              id: 'winning-1',
+              winnerId: '1001',
+              createdBy: '9001',
+              origin: 'Topcoder',
+              category: WinningsCategory.ENGAGEMENT_PAYMENT,
+              title: 'Engagement payment',
+              description: 'Monthly engagement payment',
+              externalId: 'assignment-1',
+              details: [
+                {
+                  status: PaymentStatus.OWED,
+                  totalAmount: 1200,
+                  datePaid: new Date('2026-04-09T01:02:03.000Z'),
+                  billingAccount: '80001063',
+                },
+              ],
+              paymentStatus: {} as any,
+              attributes: {},
+              createdAt: new Date('2026-04-09T01:02:03.000Z'),
+              updatedAt: new Date('2026-04-09T04:05:06.000Z'),
+              releaseDate: new Date('2026-04-24T07:08:09.000Z'),
+            },
+            {
+              id: 'winning-2',
+              winnerId: '1002',
+              createdBy: '9002',
+              origin: 'Topcoder',
+              category: WinningsCategory.ONE_OFF_PAYMENT,
+              title: 'One-off payment',
+              description: 'Non-engagement payment',
+              externalId: 'task-1',
+              details: [
+                {
+                  status: PaymentStatus.PAID,
+                  totalAmount: 500,
+                  billingAccount: '80001064',
+                },
+              ],
+              paymentStatus: {} as any,
+              attributes: {},
+              createdAt: new Date('2026-04-08T01:02:03.000Z'),
+              updatedAt: new Date('2026-04-08T04:05:06.000Z'),
+              releaseDate: new Date('2026-04-23T07:08:09.000Z'),
+            },
+          ],
+          pagination: {
+            totalItems: 2,
+            totalPages: 1,
+            pageSize: 1000,
+            currentPage: 1,
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          winnings: [],
+          pagination: {
+            totalItems: 0,
+            totalPages: 0,
+            pageSize: 1000,
+            currentPage: 2,
+          },
+        },
+      });
+    tcMembersService.getHandlesByUserIds.mockResolvedValue({
+      '1001': 'winner-one',
+      '1002': 'winner-two',
+      '9001': 'creator-handle',
+    });
+
+    const output = await controller.exportWinnings(
+      { type: WinningsType.PAYMENT } as WinningRequestDto,
+      { id: 'admin-user', roles: ['Payment Admin'] },
+    );
+
+    expect(accessControlService.applyFilters).toHaveBeenCalledWith(
+      'admin-user',
+      ['Payment Admin'],
+      {
+        type: WinningsType.PAYMENT,
+        limit: undefined,
+        offset: undefined,
+      },
+    );
+    expect(winningsRepo.searchWinnings).toHaveBeenNthCalledWith(
+      1,
+      {
+        type: WinningsType.PAYMENT,
+        limit: 1000,
+        offset: 0,
+      },
+      {
+        includeCount: false,
+        includePayoutStatus: false,
+        latestPaymentOnly: true,
+      },
+    );
+    expect(tcMembersService.getHandlesByUserIds).toHaveBeenCalledWith([
+      '1001',
+      '1002',
+      '9001',
+    ]);
+
+    const [headerRow, engagementRow, nonEngagementRow] = output
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => line.split(','));
+
+    expect(headerRow).toEqual([
+      'Winnings ID',
+      'Winner ID',
+      'Handle',
+      'Origin',
+      'Category',
+      'Title',
+      'Description',
+      'External ID',
+      'Status',
+      'Total Amount',
+      'Date Paid',
+      'Created At',
+      'Updated At',
+      'Release Date',
+      'Payment Creator',
+      'Billing Account',
+    ]);
+    expect(engagementRow[14]).toBe('creator-handle');
+    expect(nonEngagementRow[14]).toBe('');
+  });
+});

--- a/src/api/admin/admin.controller.ts
+++ b/src/api/admin/admin.controller.ts
@@ -29,7 +29,11 @@ import { AdminService } from './admin.service';
 import { ResponseDto, ResponseStatusType } from 'src/dto/api-response.dto';
 import { WinningAuditDto, AuditPayoutDto } from './dto/audit.dto';
 
-import { WinningRequestDto, SearchWinningResult } from 'src/dto/winning.dto';
+import {
+  WinningRequestDto,
+  SearchWinningResult,
+  WinningsCategory,
+} from 'src/dto/winning.dto';
 import { WinningsRepository } from '../repository/winnings.repo';
 import { WinningUpdateRequestDto } from './dto/winnings.dto';
 import { WinningPaymentDetailsDto } from './dto/payment-details.dto';
@@ -149,7 +153,7 @@ export class AdminController {
   @ApiOperation({
     summary: 'Export search winnings result in csv file format',
     description:
-      'Roles: Payment Admin, Payment BA Admin, Engagement Payment Approver, Wipro TaaS Admin, Payment Editor, Payment Viewer',
+      'Roles: Payment Admin, Payment BA Admin, Engagement Payment Approver, Wipro TaaS Admin, Payment Editor, Payment Viewer. Engagement payment exports include the Payment Creator column.',
   })
   @ApiBody({
     description: 'Winning request body',
@@ -207,9 +211,19 @@ export class AdminController {
       offset += AdminController.EXPORT_BATCH_SIZE;
     }
 
-    const handles = await this.tcMembersService.getHandlesByUserIds(
-      winnings.map((d) => d.winnerId),
+    const memberIds = Array.from(
+      new Set([
+        ...winnings.map((item) => item.winnerId),
+        ...winnings
+          .filter(
+            (item) => item.category === WinningsCategory.ENGAGEMENT_PAYMENT,
+          )
+          .map((item) => item.createdBy?.trim())
+          .filter((item): item is string => !!item),
+      ]),
     );
+
+    const handles = await this.tcMembersService.getHandlesByUserIds(memberIds);
 
     const csvRes = winnings.map((item) => {
       const payment =
@@ -230,6 +244,12 @@ export class AdminController {
         createdAt: item.createdAt.toISOString(),
         updatedAt: item.updatedAt?.toISOString() ?? '',
         releaseDate: item.releaseDate?.toISOString() ?? '',
+        paymentCreator:
+          item.category === WinningsCategory.ENGAGEMENT_PAYMENT
+            ? (handles[item.createdBy?.trim() ?? ''] ??
+              item.createdBy?.trim() ??
+              '')
+            : '',
         billingAccount: payment?.billingAccount,
       };
     });
@@ -251,6 +271,7 @@ export class AdminController {
         { key: 'createdAt', header: 'Created At' },
         { key: 'updatedAt', header: 'Updated At' },
         { key: 'releaseDate', header: 'Release Date' },
+        { key: 'paymentCreator', header: 'Payment Creator' },
         { key: 'billingAccount', header: 'Billing Account' },
       ],
     });


### PR DESCRIPTION
What was broken
The wallet-admin payments CSV download still did not include the Payment Creator column after the earlier fix. QA could see the creator in payment details, but the exported report remained unchanged.

Root cause
The previous fix only populated payment creator data for the payment-details endpoint. The CSV export path in `admin.controller.ts` assembled its own columns and rows and never added the creator field or resolved creator handles for engagement payments.

What was changed
Updated the winnings export controller to collect engagement payment creator member IDs, resolve their handles, and emit a Payment Creator column before Billing Account. The export leaves that column blank for non-engagement payment types.

Any added/updated tests
Added `src/api/admin/admin.controller.spec.ts` to verify the CSV header includes Payment Creator and that only engagement payment rows populate it.

Validation run:
- `pnpm test --runInBand src/api/admin/admin.controller.spec.ts src/api/admin/admin.service.spec.ts`
- `pnpm lint`
- `pnpm build`
- `pnpm test --runInBand` still fails on the unchanged pre-existing `src/shared/access-control/wipro-taas-admin.provider.spec.ts` because `winnings_category.TAAS_PAYMENT` is missing from the generated Prisma enum on `dev`.
