### PR TITLE
PM-4822: extend payment creator export coverage

### DIFF
--- a/src/api/admin/admin.controller.spec.ts
+++ b/src/api/admin/admin.controller.spec.ts
@@ -53,7 +53,7 @@ describe('AdminController', () => {
     );
   });
 
-  it('includes the payment creator column for engagement payment exports only', async () => {
+  it('includes the payment creator column for engagement-style payment exports only', async () => {
     accessControlService.applyFilters.mockResolvedValue({
       type: WinningsType.PAYMENT,
     } satisfies WinningRequestDto);
@@ -87,6 +87,28 @@ describe('AdminController', () => {
             {
               id: 'winning-2',
               winnerId: '1002',
+              createdBy: '9003',
+              origin: 'Topcoder',
+              category: WinningsCategory.TAAS_PAYMENT,
+              title: 'TaaS payment',
+              description: 'TaaS engagement payment',
+              externalId: 'assignment-2',
+              details: [
+                {
+                  status: PaymentStatus.PAID,
+                  totalAmount: 900,
+                  billingAccount: '80001064',
+                },
+              ],
+              paymentStatus: {} as any,
+              attributes: {},
+              createdAt: new Date('2026-04-08T01:02:03.000Z'),
+              updatedAt: new Date('2026-04-08T04:05:06.000Z'),
+              releaseDate: new Date('2026-04-23T07:08:09.000Z'),
+            },
+            {
+              id: 'winning-3',
+              winnerId: '1003',
               createdBy: '9002',
               origin: 'Topcoder',
               category: WinningsCategory.ONE_OFF_PAYMENT,
@@ -108,7 +130,7 @@ describe('AdminController', () => {
             },
           ],
           pagination: {
-            totalItems: 2,
+            totalItems: 3,
             totalPages: 1,
             pageSize: 1000,
             currentPage: 1,
@@ -129,7 +151,9 @@ describe('AdminController', () => {
     tcMembersService.getHandlesByUserIds.mockResolvedValue({
       '1001': 'winner-one',
       '1002': 'winner-two',
+      '1003': 'winner-three',
       '9001': 'creator-handle',
+      '9003': 'taas-manager',
     });
 
     const output = await controller.exportWinnings(
@@ -162,10 +186,12 @@ describe('AdminController', () => {
     expect(tcMembersService.getHandlesByUserIds).toHaveBeenCalledWith([
       '1001',
       '1002',
+      '1003',
       '9001',
+      '9003',
     ]);
 
-    const [headerRow, engagementRow, nonEngagementRow] = output
+    const [headerRow, engagementRow, taasRow, nonEngagementRow] = output
       .trim()
       .split(/\r?\n/)
       .map((line) => line.split(','));
@@ -189,6 +215,7 @@ describe('AdminController', () => {
       'Billing Account',
     ]);
     expect(engagementRow[14]).toBe('creator-handle');
+    expect(taasRow[14]).toBe('taas-manager');
     expect(nonEngagementRow[14]).toBe('');
   });
 });

--- a/src/api/admin/admin.controller.ts
+++ b/src/api/admin/admin.controller.ts
@@ -39,6 +39,11 @@ import { WinningUpdateRequestDto } from './dto/winnings.dto';
 import { WinningPaymentDetailsDto } from './dto/payment-details.dto';
 import { AccessControlService } from 'src/shared/access-control';
 
+const PAYMENT_CREATOR_EXPORT_CATEGORIES = new Set<WinningsCategory>([
+  WinningsCategory.ENGAGEMENT_PAYMENT,
+  WinningsCategory.TAAS_PAYMENT,
+]);
+
 @ApiTags('AdminWinnings')
 @Controller('/admin')
 @ApiBearerAuth()
@@ -153,7 +158,7 @@ export class AdminController {
   @ApiOperation({
     summary: 'Export search winnings result in csv file format',
     description:
-      'Roles: Payment Admin, Payment BA Admin, Engagement Payment Approver, Wipro TaaS Admin, Payment Editor, Payment Viewer. Engagement payment exports include the Payment Creator column.',
+      'Roles: Payment Admin, Payment BA Admin, Engagement Payment Approver, Wipro TaaS Admin, Payment Editor, Payment Viewer. Engagement and TaaS payment exports include the Payment Creator column.',
   })
   @ApiBody({
     description: 'Winning request body',
@@ -215,8 +220,8 @@ export class AdminController {
       new Set([
         ...winnings.map((item) => item.winnerId),
         ...winnings
-          .filter(
-            (item) => item.category === WinningsCategory.ENGAGEMENT_PAYMENT,
+          .filter((item) =>
+            PAYMENT_CREATOR_EXPORT_CATEGORIES.has(item.category),
           )
           .map((item) => item.createdBy?.trim())
           .filter((item): item is string => !!item),
@@ -244,12 +249,11 @@ export class AdminController {
         createdAt: item.createdAt.toISOString(),
         updatedAt: item.updatedAt?.toISOString() ?? '',
         releaseDate: item.releaseDate?.toISOString() ?? '',
-        paymentCreator:
-          item.category === WinningsCategory.ENGAGEMENT_PAYMENT
-            ? (handles[item.createdBy?.trim() ?? ''] ??
-              item.createdBy?.trim() ??
-              '')
-            : '',
+        paymentCreator: PAYMENT_CREATOR_EXPORT_CATEGORIES.has(item.category)
+          ? (handles[item.createdBy?.trim() ?? ''] ??
+            item.createdBy?.trim() ??
+            '')
+          : '',
         billingAccount: payment?.billingAccount,
       };
     });


### PR DESCRIPTION
What was broken
The wallet-admin CSV export only populated the Payment Creator column for ENGAGEMENT_PAYMENT rows, so TaaS payment exports still dropped the creator handle even though they follow the same admin audit flow.

Root cause (if identifiable)
The previous export fix hard-coded ENGAGEMENT_PAYMENT as the only category eligible to resolve creator handles, while wallet-admin treats TAAS_PAYMENT as a separate engagement-style payment category.

What was changed
Updated the admin winnings CSV export to use a shared set of creator-export categories and include both ENGAGEMENT_PAYMENT and TAAS_PAYMENT when resolving and writing Payment Creator values. Also updated the export endpoint description to reflect both categories.

Any added/updated tests
Expanded admin controller export coverage to verify Payment Creator is populated for both engagement and TaaS payment rows and remains blank for non-engagement payment types.
