### PR TITLE
PM-4929 - categorize topgear task reviewer payments as topgear payments

### DIFF
--- a/src/api/challenges/challenges.service.spec.ts
+++ b/src/api/challenges/challenges.service.spec.ts
@@ -116,4 +116,53 @@ describe('ChallengesService', () => {
       }),
     ]);
   });
+
+  it('maps reviewer payments to TOPGEAR_PAYMENT for topgear challenges', async () => {
+    const service = new ChallengesService(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+
+    jest.spyOn(service, 'getChallengeReviews').mockResolvedValue([
+      {
+        phaseId: 'phase-resource-1',
+        phaseName: 'Review',
+        reviewerHandle: 'reviewer1',
+      },
+    ] as any);
+
+    const payments = await service.generateReviewersPayments(
+      {
+        id: '11111111-1111-1111-1111-111111111111',
+        name: 'Topgear Review Challenge',
+        metadata: [{ name: 'payment_type', value: 'topgear' }],
+        prizeSets: [{ type: 'PLACEMENT', prizes: [{ type: PrizeType.USD, value: 500 }] }],
+        reviewers: [
+          {
+            isMemberReview: true,
+            phaseId: 'review-phase-1',
+            fixedAmount: 10,
+            baseCoefficient: 0.1,
+            incrementalCoefficient: 0.05,
+          },
+        ],
+        phases: [{ id: 'phase-resource-1', phaseId: 'review-phase-1' }],
+      } as any,
+      [
+        {
+          memberHandle: 'reviewer1',
+          memberId: 123,
+        },
+      ] as any,
+    );
+
+    expect(payments).toEqual([
+      expect.objectContaining({
+        type: WinningsCategory.TOPGEAR_PAYMENT,
+      }),
+    ]);
+  });
 });

--- a/src/api/challenges/challenges.service.ts
+++ b/src/api/challenges/challenges.service.ts
@@ -73,7 +73,9 @@ export class ChallengesService {
     private readonly winningsRepo: WinningsRepository,
   ) {}
 
-  private getDefaultWinnerCategory(challenge: Challenge): WinningsCategory {
+  private getMetadataPaymentCategory(
+    challenge: Challenge,
+  ): WinningsCategory | undefined {
     const metadataPaymentCategory = challenge.metadata?.find(
       ({ name, value }) =>
         name?.toLowerCase() === PAYMENT_TYPE_METADATA_NAME &&
@@ -87,9 +89,33 @@ export class ChallengesService {
       ];
     }
 
+    return undefined;
+  }
+
+  private getDefaultWinnerCategory(challenge: Challenge): WinningsCategory {
+    const metadataPaymentCategory = this.getMetadataPaymentCategory(challenge);
+
+    if (metadataPaymentCategory) {
+      return metadataPaymentCategory;
+    }
+
     return challenge.task.isTask
       ? WinningsCategory.TASK_PAYMENT
       : WinningsCategory.CONTEST_PAYMENT;
+  }
+
+  private getReviewerPaymentCategory(
+    challenge: Challenge,
+    currency?: PrizeType,
+  ): WinningsCategory {
+    if (currency !== PrizeType.USD) {
+      return WinningsCategory.POINTS_AWARD;
+    }
+
+    return this.getMetadataPaymentCategory(challenge) ===
+      WinningsCategory.TOPGEAR_PAYMENT
+      ? WinningsCategory.TOPGEAR_PAYMENT
+      : WinningsCategory.REVIEW_BOARD_PAYMENT;
   }
 
   async getChallenge(challengeId: string) {
@@ -378,10 +404,10 @@ export class ChallengesService {
 
             const placementPrize = placementPrizes?.[0];
             const currency = placementPrize?.type;
-            const winType =
-              currency === PrizeType.USD
-                ? WinningsCategory.REVIEW_BOARD_PAYMENT
-                : WinningsCategory.POINTS_AWARD;
+            const winType = this.getReviewerPaymentCategory(
+              challenge,
+              currency,
+            );
 
             return {
               handle: reviewer.memberHandle,


### PR DESCRIPTION
* `getReviewerPaymentCategory` determines the correct reviewer payment category based on the challenge's metadata and prize currency, supporting the "topgear" payment type.
* Updated the reviewer payment calculation in `generateReviewersPayments` to use the new `getReviewerPaymentCategory` method, ensuring the correct payment type is assigned for topgear challenges.
