### PR TITLE
PM-4826 - make sure all task payments are kept on hold (admin)

### DIFF
--- a/src/api/challenges/challenges.service.spec.ts
+++ b/src/api/challenges/challenges.service.spec.ts
@@ -24,6 +24,7 @@ jest.mock('src/shared/global', () => ({
 import { ChallengesService } from './challenges.service';
 import { PrizeType } from './models';
 import { WinningsCategory } from 'src/dto/winning.dto';
+import { PaymentStatus } from 'src/dto/payment.dto';
 
 describe('ChallengesService', () => {
   it('skips creating payments for fun challenges', async () => {
@@ -162,6 +163,92 @@ describe('ChallengesService', () => {
     expect(payments).toEqual([
       expect.objectContaining({
         type: WinningsCategory.TOPGEAR_PAYMENT,
+      }),
+    ]);
+  });
+
+  it('defaults task challenge winnings to ON_HOLD_ADMIN status', async () => {
+    const service = new ChallengesService(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+
+    jest
+      .spyOn(service, 'getChallengeResources')
+      .mockResolvedValue({ winner: [] } as any);
+    jest
+      .spyOn(service, 'generatePlacementWinnersPayments')
+      .mockReturnValue([
+        {
+          userId: '40158994',
+          amount: 500,
+          type: WinningsCategory.TASK_PAYMENT,
+          currency: PrizeType.USD,
+        },
+      ] as any);
+    jest
+      .spyOn(service, 'generateCheckpointWinnersPayments')
+      .mockReturnValue([]);
+    jest.spyOn(service, 'generateCopilotPayment').mockReturnValue([]);
+    jest.spyOn(service, 'generateReviewersPayments').mockResolvedValue([]);
+
+    const winnings = await service.getChallengePayments({
+      id: '11111111-1111-1111-1111-111111111111',
+      name: 'Task Challenge',
+      type: 'Task',
+      task: { isTask: true },
+      billing: { billingAccountId: '1234', markup: 0.2 },
+    } as any);
+
+    expect(winnings).toEqual([
+      expect.objectContaining({
+        status: PaymentStatus.ON_HOLD_ADMIN,
+      }),
+    ]);
+  });
+
+  it('does not force ON_HOLD_ADMIN status for non-task challenge winnings', async () => {
+    const service = new ChallengesService(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+
+    jest
+      .spyOn(service, 'getChallengeResources')
+      .mockResolvedValue({ winner: [] } as any);
+    jest
+      .spyOn(service, 'generatePlacementWinnersPayments')
+      .mockReturnValue([
+        {
+          userId: '40158994',
+          amount: 500,
+          type: WinningsCategory.CONTEST_PAYMENT,
+          currency: PrizeType.USD,
+        },
+      ] as any);
+    jest
+      .spyOn(service, 'generateCheckpointWinnersPayments')
+      .mockReturnValue([]);
+    jest.spyOn(service, 'generateCopilotPayment').mockReturnValue([]);
+    jest.spyOn(service, 'generateReviewersPayments').mockResolvedValue([]);
+
+    const winnings = await service.getChallengePayments({
+      id: '11111111-1111-1111-1111-111111111111',
+      name: 'Marathon Match',
+      type: 'Challenge',
+      task: { isTask: false },
+      billing: { billingAccountId: '1234', markup: 0.2 },
+    } as any);
+
+    expect(winnings).toEqual([
+      expect.not.objectContaining({
+        status: PaymentStatus.ON_HOLD_ADMIN,
       }),
     ]);
   });

--- a/src/api/challenges/challenges.service.ts
+++ b/src/api/challenges/challenges.service.ts
@@ -27,6 +27,7 @@ import {
 import { BillingAccountsService } from 'src/shared/topcoder/billing-accounts.service';
 import { TopcoderM2MService } from 'src/shared/topcoder/topcoder-m2m.service';
 import { ChallengeStatuses } from 'src/dto/challenge.dto';
+import { PaymentStatus } from 'src/dto/payment.dto';
 import { WinningsService } from '../winnings/winnings.service';
 import {
   WinningRequestDto,
@@ -495,6 +496,9 @@ export class ChallengesService {
       title: challenge.name,
       description: payment.description || challenge.name,
       externalId: challenge.id,
+      ...(challenge.task?.isTask
+        ? { status: PaymentStatus.ON_HOLD_ADMIN }
+        : {}),
       details: [
         {
           totalAmount: payment.amount,


### PR DESCRIPTION
This pull request adds logic to ensure that winnings for task challenges are created with a default status of `ON_HOLD_ADMIN`, while non-task challenges are not affected. It also introduces new tests to verify this behavior.

**Business logic changes:**

* In `ChallengesService`, winnings for task challenges now include a `status` field set to `PaymentStatus.ON_HOLD_ADMIN` by default. Non-task challenges are not forced into this status.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/tc-finance-api/pull/165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
