### PR TITLE
PM-4825 - task payment approver

### DIFF
--- a/src/api/admin/admin.controller.ts
+++ b/src/api/admin/admin.controller.ts
@@ -56,7 +56,7 @@ export class AdminController {
   @Roles(
     Role.PaymentAdmin,
     Role.PaymentBaAdmin,
-    Role.EngagementPaymentApprover,
+    Role.PaymentApprover,
     Role.WiproTaasAdmin,
     Role.PaymentEditor,
     Role.PaymentViewer,
@@ -64,7 +64,7 @@ export class AdminController {
   @ApiOperation({
     summary: 'Search winnings with parameters',
     description:
-      'Roles: Payment Admin, Payment BA Admin, Engagement Payment Approver, Wipro TaaS Admin, Payment Editor, Payment Viewer',
+      'Roles: Payment Admin, Payment BA Admin, Payment Approver, Wipro TaaS Admin, Payment Editor, Payment Viewer',
   })
   @ApiBody({
     description: 'Winning request body',
@@ -102,7 +102,7 @@ export class AdminController {
   @Roles(
     Role.PaymentAdmin,
     Role.PaymentBaAdmin,
-    Role.EngagementPaymentApprover,
+    Role.PaymentApprover,
     Role.WiproTaasAdmin,
     Role.PaymentEditor,
     Role.PaymentViewer,
@@ -145,7 +145,7 @@ export class AdminController {
   @Roles(
     Role.PaymentAdmin,
     Role.PaymentBaAdmin,
-    Role.EngagementPaymentApprover,
+    Role.PaymentApprover,
     Role.WiproTaasAdmin,
     Role.PaymentEditor,
     Role.PaymentViewer,
@@ -153,7 +153,7 @@ export class AdminController {
   @ApiOperation({
     summary: 'Export search winnings result in csv file format',
     description:
-      'Roles: Payment Admin, Payment BA Admin, Engagement Payment Approver, Wipro TaaS Admin, Payment Editor, Payment Viewer. Engagement payment exports include the Payment Creator column.',
+      'Roles: Payment Admin, Payment BA Admin, Payment Approver, Wipro TaaS Admin, Payment Editor, Payment Viewer. Engagement payment exports include the Payment Creator column.',
   })
   @ApiBody({
     description: 'Winning request body',
@@ -283,14 +283,14 @@ export class AdminController {
   @Roles(
     Role.PaymentAdmin,
     Role.PaymentBaAdmin,
-    Role.EngagementPaymentApprover,
+    Role.PaymentApprover,
     Role.WiproTaasAdmin,
     Role.PaymentEditor,
   )
   @ApiOperation({
     summary: 'Update winnings with given parameter',
     description:
-      'Roles: Payment Admin, Payment BA Admin, Engagement Payment Approver, Wipro TaaS Admin, Payment Editor. paymentStatus, releaseDate and paymentAmount cannot be null at the same time.',
+      'Roles: Payment Admin, Payment BA Admin, Payment Approver, Wipro TaaS Admin, Payment Editor. paymentStatus, releaseDate and paymentAmount cannot be null at the same time.',
   })
   @ApiResponse({
     status: 200,
@@ -330,7 +330,7 @@ export class AdminController {
   @Roles(
     Role.PaymentAdmin,
     Role.PaymentBaAdmin,
-    Role.EngagementPaymentApprover,
+    Role.PaymentApprover,
     Role.WiproTaasAdmin,
     Role.PaymentEditor,
     Role.PaymentViewer,
@@ -338,7 +338,7 @@ export class AdminController {
   @ApiOperation({
     summary: 'List winning audit logs with given winning id',
     description:
-      'Roles: Payment Admin, Payment BA Admin, Engagement Payment Approver, Wipro TaaS Admin, Payment Editor, Payment Viewer',
+      'Roles: Payment Admin, Payment BA Admin, Payment Approver, Wipro TaaS Admin, Payment Editor, Payment Viewer',
   })
   @ApiParam({
     name: 'winningID',
@@ -374,7 +374,7 @@ export class AdminController {
   @Roles(
     Role.PaymentAdmin,
     Role.PaymentBaAdmin,
-    Role.EngagementPaymentApprover,
+    Role.PaymentApprover,
     Role.WiproTaasAdmin,
     Role.PaymentEditor,
     Role.PaymentViewer,
@@ -382,7 +382,7 @@ export class AdminController {
   @ApiOperation({
     summary: 'Fetch winnings payout audit logs with given winning id.',
     description:
-      'Roles: Payment Admin, Payment BA Admin, Engagement Payment Approver, Wipro TaaS Admin, Payment Editor, Payment Viewer',
+      'Roles: Payment Admin, Payment BA Admin, Payment Approver, Wipro TaaS Admin, Payment Editor, Payment Viewer',
   })
   @ApiParam({
     name: 'winningID',

--- a/src/api/repository/winnings.repo.spec.ts
+++ b/src/api/repository/winnings.repo.spec.ts
@@ -94,4 +94,15 @@ describe('WinningsRepository', () => {
 
     expect(createdAtFilter).toBeUndefined();
   });
+
+  it('filters getWinningsByExternalId by external_id instead of winner_id', async () => {
+    await winningsRepo.getWinningsByExternalId('ext-123');
+
+    const findManyArgs = findManyMock.mock.calls[0][0];
+
+    expect(findManyArgs.where.external_id).toEqual({
+      in: ['ext-123'],
+    });
+    expect(findManyArgs.where.winner_id).toBeUndefined();
+  });
 });

--- a/src/api/repository/winnings.repo.ts
+++ b/src/api/repository/winnings.repo.ts
@@ -354,6 +354,7 @@ export class WinningsRepository {
         undefined,
         undefined,
         undefined,
+        undefined,
         [externalId],
         undefined,
       );

--- a/src/api/repository/winnings.repo.ts
+++ b/src/api/repository/winnings.repo.ts
@@ -94,6 +94,7 @@ export class WinningsRepository {
   private getWinningsQueryFilters(
     type?: string,
     category?: string,
+    categories?: string[],
     status?: string,
     winnerIds?: string[],
     externalIds?: string[],
@@ -120,7 +121,11 @@ export class WinningsRepository {
         ? {
             equals: category as winnings_category,
           }
-        : undefined,
+        : categories?.length
+          ? {
+              in: categories as winnings_category[],
+            }
+          : undefined,
       type: typeFilter,
       payment: status
         ? {
@@ -219,6 +224,7 @@ export class WinningsRepository {
       const queryWhere = this.getWinningsQueryFilters(
         searchProps.type,
         searchProps.category,
+        searchProps.categories,
         searchProps.status,
         winnerIds,
         externalIds,

--- a/src/core/auth/auth.constants.ts
+++ b/src/core/auth/auth.constants.ts
@@ -2,7 +2,7 @@ export enum Role {
   Administrator = 'Administrator',
   PaymentAdmin = 'Payment Admin',
   PaymentBaAdmin = 'Payment BA Admin',
-  EngagementPaymentApprover = 'Engagement Payment Approver',
+  PaymentApprover = 'Payment Approver',
   WiproTaasAdmin = 'Wipro TaaS Admin',
   PaymentEditor = 'Payment Editor',
   PaymentViewer = 'Payment Viewer',

--- a/src/dto/winning.dto.ts
+++ b/src/dto/winning.dto.ts
@@ -170,7 +170,17 @@ export class WinningRequestDto extends SortPagination {
   category?: WinningsCategory;
 
   @ApiProperty({
-    description: 'The type of winnings',
+    description: 'Multiple winnings categories to filter by',
+    enum: WinningsCategory,
+    isArray: true,
+    example: [WinningsCategory.ENGAGEMENT_PAYMENT, WinningsCategory.TASK_PAYMENT],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsEnum(WinningsCategory, { each: true })
+  categories?: WinningsCategory[];
+
+  @ApiProperty({
     enum: WinningsType,
     example: WinningsType.PAYMENT,
   })

--- a/src/shared/access-control/access-control.module.ts
+++ b/src/shared/access-control/access-control.module.ts
@@ -1,7 +1,7 @@
 import { Injectable, Module } from '@nestjs/common';
 import { AccessControlService } from 'src/shared/access-control/access-control.service';
 import { PaymentBaProvider } from 'src/shared/access-control/payment-ba.provider';
-import { EngagementPaymentApproverProvider } from 'src/shared/access-control/engagement-pa.provider';
+import { PaymentApproverProvider } from 'src/shared/access-control/payment-approver.provider';
 import { WiproTaasAdminProvider } from 'src/shared/access-control/wipro-taas-admin.provider';
 import { TopcoderModule } from '../topcoder/topcoder.module';
 
@@ -10,11 +10,11 @@ class AccessControlRegistrar {
   constructor(
     accessControlService: AccessControlService,
     paymentBaProvider: PaymentBaProvider,
-    engagementPaymentApproverProvider: EngagementPaymentApproverProvider,
+    paymentApproverProvider: PaymentApproverProvider,
     wiproTaasAdminProvider: WiproTaasAdminProvider,
   ) {
     accessControlService.register(paymentBaProvider);
-    accessControlService.register(engagementPaymentApproverProvider);
+    accessControlService.register(paymentApproverProvider);
     accessControlService.register(wiproTaasAdminProvider);
   }
 }
@@ -25,7 +25,7 @@ class AccessControlRegistrar {
   providers: [
     AccessControlService,
     PaymentBaProvider,
-    EngagementPaymentApproverProvider,
+    PaymentApproverProvider,
     WiproTaasAdminProvider,
     AccessControlRegistrar,
   ],

--- a/src/shared/access-control/access-control.service.spec.ts
+++ b/src/shared/access-control/access-control.service.spec.ts
@@ -9,7 +9,7 @@ describe('AccessControlService', () => {
     service = new AccessControlService();
   });
 
-  it('skips engagement approver filters when payment admin role is also present', async () => {
+  it('skips approver filters when payment admin role is also present', async () => {
     const paymentAdminApplyFilter = jest
       .fn()
       .mockImplementation((_userId, req: Record<string, unknown>) =>
@@ -18,31 +18,31 @@ describe('AccessControlService', () => {
           admin: true,
         }),
       );
-    const engagementApproverApplyFilter = jest
+    const approverApplyFilter = jest
       .fn()
       .mockImplementation((_userId, req: Record<string, unknown>) =>
         Promise.resolve({
           ...req,
-          category: 'ENGAGEMENT_PAYMENT',
+          categories: ['ENGAGEMENT_PAYMENT', 'TASK_PAYMENT'],
         }),
       );
     const paymentAdminProvider: RoleAccessProvider<Record<string, unknown>> = {
       roleName: Role.PaymentAdmin,
       applyFilter: paymentAdminApplyFilter,
     };
-    const engagementApproverProvider: RoleAccessProvider<
+    const approverProvider: RoleAccessProvider<
       Record<string, unknown>
     > = {
-      roleName: Role.EngagementPaymentApprover,
-      applyFilter: engagementApproverApplyFilter,
+      roleName: Role.PaymentApprover,
+      applyFilter: approverApplyFilter,
     };
 
     service.register(paymentAdminProvider);
-    service.register(engagementApproverProvider);
+    service.register(approverProvider);
 
     const result = await service.applyFilters<Record<string, unknown>>(
       '88770025',
-      [Role.PaymentAdmin, Role.EngagementPaymentApprover],
+      [Role.PaymentAdmin, Role.PaymentApprover],
       { type: 'PAYMENT' },
     );
 
@@ -51,38 +51,38 @@ describe('AccessControlService', () => {
       type: 'PAYMENT',
     });
     expect(paymentAdminApplyFilter).toHaveBeenCalledTimes(1);
-    expect(engagementApproverApplyFilter).not.toHaveBeenCalled();
+    expect(approverApplyFilter).not.toHaveBeenCalled();
   });
 
-  it('applies engagement approver filters when payment admin role is absent', async () => {
-    const engagementApproverApplyFilter = jest
+  it('applies approver filters when payment admin role is absent', async () => {
+    const approverApplyFilter = jest
       .fn()
       .mockImplementation((_userId, req: Record<string, unknown>) =>
         Promise.resolve({
           ...req,
-          category: 'ENGAGEMENT_PAYMENT',
+          categories: ['ENGAGEMENT_PAYMENT', 'TASK_PAYMENT'],
         }),
       );
-    const engagementApproverProvider: RoleAccessProvider<
+    const approverProvider: RoleAccessProvider<
       Record<string, unknown>
     > = {
-      roleName: Role.EngagementPaymentApprover,
-      applyFilter: engagementApproverApplyFilter,
+      roleName: Role.PaymentApprover,
+      applyFilter: approverApplyFilter,
     };
 
-    service.register(engagementApproverProvider);
+    service.register(approverProvider);
 
     const result = await service.applyFilters<Record<string, unknown>>(
       '88770025',
-      [Role.EngagementPaymentApprover],
+      [Role.PaymentApprover],
       { type: 'PAYMENT' },
     );
 
     expect(result).toEqual({
-      category: 'ENGAGEMENT_PAYMENT',
+      categories: ['ENGAGEMENT_PAYMENT', 'TASK_PAYMENT'],
       type: 'PAYMENT',
     });
-    expect(engagementApproverApplyFilter).toHaveBeenCalledTimes(1);
+    expect(approverApplyFilter).toHaveBeenCalledTimes(1);
   });
 
   it('applies wipro taas admin filters when payment admin role is absent', async () => {
@@ -115,32 +115,32 @@ describe('AccessControlService', () => {
     expect(wiproTaasAdminApplyFilter).toHaveBeenCalledTimes(1);
   });
 
-  it('skips engagement approver resource checks when payment admin role is also present', async () => {
+  it('skips approver resource checks when payment admin role is also present', async () => {
     const paymentAdminVerifyAccess = jest.fn().mockResolvedValue(undefined);
-    const engagementApproverVerifyAccess = jest
+    const approverVerifyAccess = jest
       .fn()
       .mockRejectedValue(new Error('should not be called'));
     const paymentAdminProvider: RoleAccessProvider = {
       roleName: Role.PaymentAdmin,
       verifyAccessToResource: paymentAdminVerifyAccess,
     };
-    const engagementApproverProvider: RoleAccessProvider = {
-      roleName: Role.EngagementPaymentApprover,
-      verifyAccessToResource: engagementApproverVerifyAccess,
+    const approverProvider: RoleAccessProvider = {
+      roleName: Role.PaymentApprover,
+      verifyAccessToResource: approverVerifyAccess,
     };
 
     service.register(paymentAdminProvider);
-    service.register(engagementApproverProvider);
+    service.register(approverProvider);
 
     await expect(
       service.verifyAccess('winning-id', '88770025', [
         Role.PaymentAdmin,
-        Role.EngagementPaymentApprover,
+        Role.PaymentApprover,
       ]),
     ).resolves.toBeUndefined();
 
     expect(paymentAdminVerifyAccess).toHaveBeenCalledTimes(1);
-    expect(engagementApproverVerifyAccess).not.toHaveBeenCalled();
+    expect(approverVerifyAccess).not.toHaveBeenCalled();
   });
 
   it('skips wipro taas admin resource checks when payment admin role is also present', async () => {

--- a/src/shared/access-control/access-control.service.ts
+++ b/src/shared/access-control/access-control.service.ts
@@ -21,7 +21,7 @@ export class AccessControlService {
     normalizedRoles: Set<string>,
   ): boolean {
     const isCategoryScopedApproverRole =
-      providerRole === Role.EngagementPaymentApprover.trim().toLowerCase() ||
+      providerRole === Role.PaymentApprover.trim().toLowerCase() ||
       providerRole === Role.WiproTaasAdmin.trim().toLowerCase();
 
     return (

--- a/src/shared/access-control/payment-approver.provider.spec.ts
+++ b/src/shared/access-control/payment-approver.provider.spec.ts
@@ -1,0 +1,82 @@
+jest.mock('src/shared/global/prisma.service', () => ({
+  PrismaService: class {},
+}));
+
+import { winnings_category } from '@prisma/client';
+import { Role } from 'src/core/auth/auth.constants';
+import { PaymentApproverProvider } from './payment-approver.provider';
+
+describe('PaymentApproverProvider', () => {
+  let provider: PaymentApproverProvider;
+  let prisma: {
+    winnings: {
+      findMany: jest.Mock;
+    };
+  };
+
+  beforeEach(() => {
+    prisma = {
+      winnings: {
+        findMany: jest.fn(),
+      },
+    };
+
+    provider = new PaymentApproverProvider(prisma as any);
+  });
+
+  it('replaces incoming category filters with allowed payment approver categories', async () => {
+    const result = await provider.applyFilter<Record<string, unknown>>(
+      '123456',
+      {
+        categories: [winnings_category.ALGORITHM_CONTEST_PAYMENT],
+        category: winnings_category.ALGORITHM_CONTEST_PAYMENT,
+        limit: 10,
+        type: 'PAYMENT',
+      },
+    );
+
+    expect(result).toEqual({
+      categories: [
+        winnings_category.ENGAGEMENT_PAYMENT,
+        winnings_category.TASK_PAYMENT,
+      ],
+      limit: 10,
+      type: 'PAYMENT',
+    });
+    expect(result).not.toHaveProperty('category');
+  });
+
+  it('allows access when all winnings are approver-allowed categories', async () => {
+    prisma.winnings.findMany.mockResolvedValue([
+      { category: winnings_category.ENGAGEMENT_PAYMENT },
+      { category: winnings_category.TASK_PAYMENT },
+    ]);
+
+    await expect(
+      provider.verifyAccessToResource(['winning-1', 'winning-2'], '123456'),
+    ).resolves.toBeUndefined();
+
+    expect(prisma.winnings.findMany).toHaveBeenCalledWith({
+      where: { winning_id: { in: ['winning-1', 'winning-2'] } },
+      select: { category: true },
+    });
+  });
+
+  it('rejects access when any winning is outside the allowed categories', async () => {
+    prisma.winnings.findMany.mockResolvedValue([
+      { category: winnings_category.ENGAGEMENT_PAYMENT },
+      { category: winnings_category.ALGORITHM_CONTEST_PAYMENT },
+    ]);
+
+    await expect(
+      provider.verifyAccessToResource('winning-1', '123456'),
+    ).rejects.toThrow(
+      `${Role.PaymentApprover} user is trying to access winning with category='${winnings_category.ALGORITHM_CONTEST_PAYMENT}'`,
+    );
+
+    expect(prisma.winnings.findMany).toHaveBeenCalledWith({
+      where: { winning_id: { in: ['winning-1'] } },
+      select: { category: true },
+    });
+  });
+});

--- a/src/shared/access-control/payment-approver.provider.ts
+++ b/src/shared/access-control/payment-approver.provider.ts
@@ -18,14 +18,13 @@ export class PaymentApproverProvider implements RoleAccessProvider {
   // disable rule: prefer this format instead of returning resolved promise (required by interface)
   // eslint-disable-next-line @typescript-eslint/require-await
   async applyFilter<T>(_userId: string, req: any): Promise<T> {
-    // If the request already has a specific category, preserve it (access is
-    // validated per-resource via verifyAccessToResource). Otherwise restrict the
-    // query to all categories allowed for this role.
-    if (req.category) {
-      return req as T;
-    }
+    const { category: _ignoredCategory, categories: _ignoredCategories, ...rest } =
+      req ?? {};
 
-    return { ...req, categories: allowedCategories } as T;
+    return {
+      ...rest,
+      categories: allowedCategories,
+    } as T;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -37,9 +36,11 @@ export class PaymentApproverProvider implements RoleAccessProvider {
       select: { category: true },
     });
 
-    const unauthorized = winnings.filter(
-      (w) => !allowedCategories.includes(w.category),
-    );
+    const unauthorized = winnings.filter((w) => {
+      const category = w.category;
+
+      return category === null || !allowedCategories.includes(category);
+    });
     if (unauthorized.length > 0) {
       throw new Error(
         `${Role.PaymentApprover} user is trying to access winning with category='${unauthorized.map((w) => w.category).join(', ')}'`,

--- a/src/shared/access-control/payment-approver.provider.ts
+++ b/src/shared/access-control/payment-approver.provider.ts
@@ -4,16 +4,28 @@ import { PrismaService } from 'src/shared/global/prisma.service';
 import { Role } from 'src/core/auth/auth.constants';
 import { winnings_category } from '@prisma/client';
 
+const allowedCategories: winnings_category[] = [
+  winnings_category.ENGAGEMENT_PAYMENT,
+  winnings_category.TASK_PAYMENT,
+];
+
 @Injectable()
-export class EngagementPaymentApproverProvider implements RoleAccessProvider {
-  roleName = Role.EngagementPaymentApprover;
+export class PaymentApproverProvider implements RoleAccessProvider {
+  roleName = Role.PaymentApprover;
 
   constructor(private readonly prisma: PrismaService) {}
 
   // disable rule: prefer this format instead of returning resolved promise (required by interface)
   // eslint-disable-next-line @typescript-eslint/require-await
-  async applyFilter<T>(userId: string, req: any): Promise<T> {
-    return { ...req, category: winnings_category.ENGAGEMENT_PAYMENT } as T;
+  async applyFilter<T>(_userId: string, req: any): Promise<T> {
+    // If the request already has a specific category, preserve it (access is
+    // validated per-resource via verifyAccessToResource). Otherwise restrict the
+    // query to all categories allowed for this role.
+    if (req.category) {
+      return req as T;
+    }
+
+    return { ...req, categories: allowedCategories } as T;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -26,11 +38,11 @@ export class EngagementPaymentApproverProvider implements RoleAccessProvider {
     });
 
     const unauthorized = winnings.filter(
-      (w) => w.category !== winnings_category.ENGAGEMENT_PAYMENT,
+      (w) => !allowedCategories.includes(w.category),
     );
     if (unauthorized.length > 0) {
       throw new Error(
-        `${Role.EngagementPaymentApprover} user is trying to access winning with category='${unauthorized.map((w) => w.category).join(', ')}'`,
+        `${Role.PaymentApprover} user is trying to access winning with category='${unauthorized.map((w) => w.category).join(', ')}'`,
       );
     }
   }


### PR DESCRIPTION
This pull request makes two main updates: it renames the "Engagement Payment Approver" role to "Payment Approver" throughout the codebase, and it expands the permissions for this role to cover both "ENGAGEMENT_PAYMENT" and "TASK_PAYMENT" winnings categories. Additionally, it introduces support for filtering by multiple winnings categories in relevant endpoints and data transfer objects.

**Role Renaming and Permission Expansion:**

* The `Role.EngagementPaymentApprover` is renamed to `Role.PaymentApprover` everywhere, including in the `auth.constants.ts`, access control providers, controller decorators, and tests. 
* The access control provider previously named `EngagementPaymentApproverProvider` is renamed to `PaymentApproverProvider`, and its logic now allows access to both `ENGAGEMENT_PAYMENT` and `TASK_PAYMENT` categories. 

**Winnings Filtering Enhancements:**

* The winnings repository and related DTOs are updated to support filtering by multiple categories via a new `categories` array parameter, in addition to the existing single `category` filter. 
* The `PaymentApproverProvider` applies a filter to restrict queries to the allowed categories unless a specific category is already provided in the request.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/tc-finance-api/pull/166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
