### PR TITLE
PM-4825 - show task payment details

### DIFF
--- a/src/api/admin/admin.service.spec.ts
+++ b/src/api/admin/admin.service.spec.ts
@@ -40,6 +40,10 @@ jest.mock('src/shared/topcoder/members.service', () => ({
   TopcoderMembersService: class {},
 }));
 
+jest.mock('src/shared/topcoder/challenges.service', () => ({
+  TopcoderChallengesService: class {},
+}));
+
 import { AdminService } from './admin.service';
 
 describe('AdminService', () => {

--- a/src/api/admin/admin.service.spec.ts
+++ b/src/api/admin/admin.service.spec.ts
@@ -45,6 +45,9 @@ import { AdminService } from './admin.service';
 describe('AdminService', () => {
   let service: AdminService;
   let prisma: {
+    audit: {
+      findMany: jest.Mock;
+    };
     winnings: {
       findFirst: jest.Mock;
     };
@@ -61,9 +64,16 @@ describe('AdminService', () => {
   let tcMembersService: {
     getHandlesByUserIds: jest.Mock;
   };
+  let topcoderChallengesService: {
+    getChallengeById: jest.Mock;
+    getProjectById: jest.Mock;
+  };
 
   beforeEach(() => {
     prisma = {
+      audit: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
       winnings: {
         findFirst: jest.fn(),
       },
@@ -82,6 +92,10 @@ describe('AdminService', () => {
         '654321': 'payment-manager',
       }),
     };
+    topcoderChallengesService = {
+      getChallengeById: jest.fn().mockResolvedValue(undefined),
+      getProjectById: jest.fn().mockResolvedValue(undefined),
+    };
 
     service = new AdminService(
       prisma as any,
@@ -90,6 +104,7 @@ describe('AdminService', () => {
       accessControlService as any,
       topcoderEngagementsService as any,
       tcMembersService as any,
+      topcoderChallengesService as any,
     );
   });
 
@@ -322,5 +337,47 @@ describe('AdminService', () => {
     await expect(
       service.getWinningPaymentDetails('missing-winning', '123456', []),
     ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('returns task details for task payment with projectId and approver', async () => {
+    prisma.winnings.findFirst.mockResolvedValue({
+      winning_id: 'winning-task',
+      category: 'TASK_PAYMENT',
+      created_by: '654321',
+      winner_id: '123456',
+      external_id: 'challenge-uuid-1',
+      attributes: {},
+    });
+    topcoderChallengesService.getChallengeById.mockResolvedValue({
+      id: 'challenge-uuid-1',
+      name: 'Build a widget',
+      projectId: 42,
+    });
+    topcoderChallengesService.getProjectById.mockResolvedValue({
+      id: 42,
+      name: 'My Project',
+    });
+    prisma.audit.findMany.mockResolvedValue([
+      {
+        id: 'audit-1',
+        winnings_id: 'winning-task',
+        user_id: '654321',
+        action: 'status updated from ON_HOLD_ADMIN to OWED',
+        note: null,
+        created_at: new Date(),
+      },
+    ]);
+
+    const result = await service.getWinningPaymentDetails(
+      'winning-task',
+      '123456',
+      ['Payment Admin'],
+    );
+
+    expect(result.data?.taskDetails?.projectId).toBe('42');
+    expect(result.data?.taskDetails?.projectName).toBe('My Project');
+    expect(result.data?.taskDetails?.paymentApproverHandle).toBe(
+      'payment-manager',
+    );
   });
 });

--- a/src/api/admin/admin.service.ts
+++ b/src/api/admin/admin.service.ts
@@ -752,6 +752,8 @@ export class AdminService {
       const approverAudit = audits.find(
         (a) =>
           typeof a.action === 'string' &&
+          a.action.includes('ON_HOLD_ADMIN') &&
+          a.action.includes('OWED') &&
           a.action.indexOf('ON_HOLD_ADMIN') < a.action.indexOf('OWED'),
       );
       if (approverAudit?.user_id) {

--- a/src/api/admin/admin.service.ts
+++ b/src/api/admin/admin.service.ts
@@ -23,6 +23,7 @@ import {
   TopcoderEngagementsService,
 } from 'src/shared/topcoder/engagements.service';
 import { TopcoderMembersService } from 'src/shared/topcoder/members.service';
+import { TopcoderChallengesService } from 'src/shared/topcoder/challenges.service';
 import { WinningPaymentDetailsDto } from './dto/payment-details.dto';
 
 /**
@@ -43,6 +44,7 @@ export class AdminService {
     private readonly accessControlService: AccessControlService,
     private readonly topcoderEngagementsService: TopcoderEngagementsService,
     private readonly tcMembersService: TopcoderMembersService,
+    private readonly topcoderChallengesService: TopcoderChallengesService,
   ) {}
 
   async verifyUserAccessToWinning(
@@ -712,6 +714,58 @@ export class AdminService {
     return result;
   }
 
+  private async buildTaskDetails(
+    winningsId: string,
+    externalId: string | undefined,
+  ): Promise<WinningPaymentDetailsDto['taskDetails']> {
+    const taskDetails: WinningPaymentDetailsDto['taskDetails'] = {};
+
+    if (externalId) {
+      try {
+        const challenge =
+          await this.topcoderChallengesService.getChallengeById(externalId);
+        if (challenge?.projectId) {
+          taskDetails.projectId = String(challenge.projectId);
+          try {
+            const project = await this.topcoderChallengesService.getProjectById(
+              challenge.projectId,
+            );
+            if (project?.name) {
+              taskDetails.projectName = project.name;
+            }
+          } catch {
+            // project name is optional — ignore failures
+          }
+        }
+      } catch {
+        // projectId is optional — ignore failures
+      }
+    }
+
+    try {
+      const audits = await this.prisma.audit.findMany({
+        where: { winnings_id: winningsId },
+        orderBy: { created_at: 'asc' },
+        take: 200,
+      });
+
+      const approverAudit = audits.find(
+        (a) =>
+          typeof a.action === 'string' &&
+          a.action.indexOf('ON_HOLD_ADMIN') < a.action.indexOf('OWED'),
+      );
+      if (approverAudit?.user_id) {
+        const userId = String(approverAudit.user_id);
+        const handle = await this.getPaymentCreatorHandle(userId);
+        taskDetails.paymentApproverHandle = handle ?? undefined;
+      }
+    } catch {
+      // approver is optional — ignore failures
+    }
+
+    return taskDetails;
+  }
+
   async getWinningPaymentDetails(
     winningsId: string,
     userId: string,
@@ -746,6 +800,16 @@ export class AdminService {
         : undefined;
     const assignmentLookupId = assignmentId ?? externalId;
     const isEngagementPayment = winning.category === 'ENGAGEMENT_PAYMENT';
+
+    const isTaskPayment = winning.category === 'TASK_PAYMENT';
+
+    if (isTaskPayment) {
+      result.data.taskDetails = await this.buildTaskDetails(
+        winningsId,
+        externalId,
+      );
+      return result;
+    }
 
     if (!isEngagementPayment) {
       return result;

--- a/src/api/admin/admin.service.ts
+++ b/src/api/admin/admin.service.ts
@@ -745,10 +745,9 @@ export class AdminService {
     try {
       const audits = await this.prisma.audit.findMany({
         where: { winnings_id: winningsId },
-        orderBy: { created_at: 'asc' },
+        orderBy: { created_at: 'desc' },
         take: 200,
       });
-
       const approverAudit = audits.find(
         (a) =>
           typeof a.action === 'string' &&

--- a/src/api/admin/dto/payment-details.dto.ts
+++ b/src/api/admin/dto/payment-details.dto.ts
@@ -76,6 +76,26 @@ export class PaymentWorkLogDto {
   remarks?: string;
 }
 
+export class PaymentTaskDetailsDto {
+  @ApiPropertyOptional({
+    description: 'The Connect project ID associated with the task challenge',
+    example: '12345',
+  })
+  projectId?: string;
+
+  @ApiPropertyOptional({
+    description: 'The name of the project associated with the task challenge',
+    example: 'Platform Modernization',
+  })
+  projectName?: string;
+
+  @ApiPropertyOptional({
+    description: 'The Topcoder handle of the user who approved this payment',
+    example: 'approver_handle',
+  })
+  paymentApproverHandle?: string;
+}
+
 export class WinningPaymentDetailsDto {
   @ApiPropertyOptional({
     description:
@@ -96,4 +116,10 @@ export class WinningPaymentDetailsDto {
     type: PaymentWorkLogDto,
   })
   workLog?: PaymentWorkLogDto;
+
+  @ApiPropertyOptional({
+    description: 'Task-specific details when the winning is a task payment',
+    type: PaymentTaskDetailsDto,
+  })
+  taskDetails?: PaymentTaskDetailsDto;
 }

--- a/src/shared/topcoder/challenges.service.ts
+++ b/src/shared/topcoder/challenges.service.ts
@@ -1,6 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import { TopcoderM2MService } from './topcoder-m2m.service';
+import { ENV_CONFIG } from 'src/config';
 import { Logger } from 'src/shared/global';
+
+import { TopcoderM2MService } from './topcoder-m2m.service';
+
+const { TOPCODER_API_V6_BASE_URL: TC_API_V6_BASE } = ENV_CONFIG;
 
 export interface WithdrawUpdateData {
   userId: number;
@@ -14,9 +18,53 @@ export interface AdminPaymentUpdateData {
   amount: number;
   releaseDate: string;
 }
+
+export interface TopcoderChallengeInfo {
+  id: string;
+  name: string;
+  projectId: number;
+}
+
+export interface TopcoderProjectInfo {
+  id: number;
+  name: string;
+}
+
 @Injectable()
 export class TopcoderChallengesService {
   private readonly logger = new Logger(TopcoderChallengesService.name);
 
   constructor(private readonly m2MService: TopcoderM2MService) {}
+
+  async getChallengeById(
+    challengeId: string,
+  ): Promise<TopcoderChallengeInfo | undefined> {
+    try {
+      return await this.m2MService.m2mFetch<TopcoderChallengeInfo>(
+        `${TC_API_V6_BASE}/challenges/${challengeId}`,
+      );
+    } catch (error) {
+      this.logger.warn(
+        `Failed to fetch challenge ${challengeId}`,
+        error instanceof Error ? error.message : error,
+      );
+      return undefined;
+    }
+  }
+
+  async getProjectById(
+    projectId: number,
+  ): Promise<TopcoderProjectInfo | undefined> {
+    try {
+      return await this.m2MService.m2mFetch<TopcoderProjectInfo>(
+        `${TC_API_V6_BASE}/projects/${projectId}`,
+      );
+    } catch (error) {
+      this.logger.warn(
+        `Failed to fetch project ${projectId}`,
+        error instanceof Error ? error.message : error,
+      );
+      return undefined;
+    }
+  }
 }


### PR DESCRIPTION
This pull request adds support for returning additional task-specific details when fetching winning payment details for task payments. It introduces a new DTO for task details, updates the `AdminService` to fetch and return project and approver information for task payments, and adds a new service for interacting with Topcoder's challenges and projects APIs. The most important changes are:

**Task Payment Details Enhancement:**

* Added a new `PaymentTaskDetailsDto` class and an optional `taskDetails` field to `WinningPaymentDetailsDto` to hold project ID, project name, and payment approver handle for task payments. (`src/api/admin/dto/payment-details.dto.ts`)
* Updated `AdminService` to include a `buildTaskDetails` method that fetches challenge and project info from Topcoder APIs and determines the payment approver from audit logs. This method is called when the winning is a task payment, and the result is included in the response. (`src/api/admin/admin.service.ts`)

**Integration with Topcoder Challenges API:**

* Added a new `TopcoderChallengesService` with methods `getChallengeById` and `getProjectById` to fetch challenge and project data from Topcoder's API v6. (`src/shared/topcoder/challenges.service.ts`) 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/tc-finance-api/pull/167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
