### PR TITLE
PM-4951: Lock draft challenge payment budget

### DIFF
--- a/src/api/admin/admin.service.ts
+++ b/src/api/admin/admin.service.ts
@@ -726,7 +726,7 @@ export class AdminService {
           await this.topcoderChallengesService.getChallengeById(externalId);
         if (challenge?.createdBy) {
           taskDetails.paymentCreatorHandle = await this.getPaymentCreatorHandle(
-            challenge.createdBy
+            challenge.createdBy,
           );
         }
         if (challenge?.projectId) {

--- a/src/api/challenges/challenges.service.spec.ts
+++ b/src/api/challenges/challenges.service.spec.ts
@@ -25,6 +25,7 @@ import { ChallengesService } from './challenges.service';
 import { PrizeType } from './models';
 import { WinningsCategory } from 'src/dto/winning.dto';
 import { PaymentStatus } from 'src/dto/payment.dto';
+import { CHALLENGE_BUDGET_SYNC_SKIP_ATTRIBUTE } from '../winnings/winnings.service';
 
 describe('ChallengesService', () => {
   it('skips creating payments for fun challenges', async () => {
@@ -181,16 +182,14 @@ describe('ChallengesService', () => {
     jest
       .spyOn(service, 'getChallengeResources')
       .mockResolvedValue({ winner: [] } as any);
-    jest
-      .spyOn(service, 'generatePlacementWinnersPayments')
-      .mockReturnValue([
-        {
-          userId: '40158994',
-          amount: 500,
-          type: WinningsCategory.TASK_PAYMENT,
-          currency: PrizeType.USD,
-        },
-      ] as any);
+    jest.spyOn(service, 'generatePlacementWinnersPayments').mockReturnValue([
+      {
+        userId: '40158994',
+        amount: 500,
+        type: WinningsCategory.TASK_PAYMENT,
+        currency: PrizeType.USD,
+      },
+    ] as any);
     jest
       .spyOn(service, 'generateCheckpointWinnersPayments')
       .mockReturnValue([]);
@@ -210,6 +209,9 @@ describe('ChallengesService', () => {
         status: PaymentStatus.ON_HOLD_ADMIN,
       }),
     ]);
+    expect(winnings[0].attributes).toMatchObject({
+      [CHALLENGE_BUDGET_SYNC_SKIP_ATTRIBUTE]: true,
+    });
   });
 
   it('does not force ON_HOLD_ADMIN status for non-task challenge winnings', async () => {
@@ -224,16 +226,14 @@ describe('ChallengesService', () => {
     jest
       .spyOn(service, 'getChallengeResources')
       .mockResolvedValue({ winner: [] } as any);
-    jest
-      .spyOn(service, 'generatePlacementWinnersPayments')
-      .mockReturnValue([
-        {
-          userId: '40158994',
-          amount: 500,
-          type: WinningsCategory.CONTEST_PAYMENT,
-          currency: PrizeType.USD,
-        },
-      ] as any);
+    jest.spyOn(service, 'generatePlacementWinnersPayments').mockReturnValue([
+      {
+        userId: '40158994',
+        amount: 500,
+        type: WinningsCategory.CONTEST_PAYMENT,
+        currency: PrizeType.USD,
+      },
+    ] as any);
     jest
       .spyOn(service, 'generateCheckpointWinnersPayments')
       .mockReturnValue([]);

--- a/src/api/challenges/challenges.service.ts
+++ b/src/api/challenges/challenges.service.ts
@@ -28,7 +28,10 @@ import { BillingAccountsService } from 'src/shared/topcoder/billing-accounts.ser
 import { TopcoderM2MService } from 'src/shared/topcoder/topcoder-m2m.service';
 import { ChallengeStatuses } from 'src/dto/challenge.dto';
 import { PaymentStatus } from 'src/dto/payment.dto';
-import { WinningsService } from '../winnings/winnings.service';
+import {
+  CHALLENGE_BUDGET_SYNC_SKIP_ATTRIBUTE,
+  WinningsService,
+} from '../winnings/winnings.service';
 import {
   WinningRequestDto,
   WinningsCategory,
@@ -492,36 +495,45 @@ export class ChallengesService {
       0,
     );
 
-    return payments.map((payment) => ({
-      winnerId: payment.userId.toString(),
-      type:
-        payment.currency === PrizeType.USD
-          ? WinningsType.PAYMENT
-          : WinningsType.POINTS,
-      origin: 'Topcoder',
-      category: payment.type,
-      title: challenge.name,
-      description: payment.description || challenge.name,
-      externalId: challenge.id,
-      ...(payment.status ? { status: payment.status } : {}),
-      details: [
-        {
-          totalAmount: payment.amount,
-          grossAmount: payment.amount,
-          installmentNumber: 1,
-          currency: payment.currency || PrizeType.USD,
-          billingAccount: `${challenge.billing.billingAccountId}`,
-          challengeFee: totalUsdAmount * challenge.billing.markup,
+    return payments.map((payment) => {
+      const paymentStatus =
+        payment.status ??
+        (challenge.task?.isTask && payment.currency === PrizeType.USD
+          ? PaymentStatus.ON_HOLD_ADMIN
+          : undefined);
+
+      return {
+        winnerId: payment.userId.toString(),
+        type:
+          payment.currency === PrizeType.USD
+            ? WinningsType.PAYMENT
+            : WinningsType.POINTS,
+        origin: 'Topcoder',
+        category: payment.type,
+        title: challenge.name,
+        description: payment.description || challenge.name,
+        externalId: challenge.id,
+        ...(paymentStatus ? { status: paymentStatus } : {}),
+        details: [
+          {
+            totalAmount: payment.amount,
+            grossAmount: payment.amount,
+            installmentNumber: 1,
+            currency: payment.currency || PrizeType.USD,
+            billingAccount: `${challenge.billing.billingAccountId}`,
+            challengeFee: totalUsdAmount * challenge.billing.markup,
+          },
+        ],
+        attributes: {
+          billingAccountId: challenge.billing.billingAccountId,
+          [CHALLENGE_BUDGET_SYNC_SKIP_ATTRIBUTE]: true,
+          payroll: includes(
+            TGBillingAccounts,
+            parseInt(challenge.billing.billingAccountId),
+          ),
         },
-      ],
-      attributes: {
-        billingAccountId: challenge.billing.billingAccountId,
-        payroll: includes(
-          TGBillingAccounts,
-          parseInt(challenge.billing.billingAccountId),
-        ),
-      },
-    }));
+      };
+    });
   }
 
   private async createPayments(challenge: Challenge, userId: string) {

--- a/src/api/winnings/winnings.service.spec.ts
+++ b/src/api/winnings/winnings.service.spec.ts
@@ -24,11 +24,17 @@ import {
   BadRequestException,
   InternalServerErrorException,
 } from '@nestjs/common';
-import { WinningsService } from './winnings.service';
+import {
+  CHALLENGE_BUDGET_SYNC_SKIP_ATTRIBUTE,
+  WinningsService,
+} from './winnings.service';
 import { PrizeType } from '../challenges/models';
 import { WinningsCategory, WinningsType } from 'src/dto/winning.dto';
 
 interface TestTransactionClient {
+  payment: {
+    findMany: jest.Mock;
+  };
   winnings: {
     create: jest.Mock;
   };
@@ -47,6 +53,10 @@ describe('WinningsService', () => {
   let billingAccountsService: {
     consumeAmounts: jest.Mock;
     getBillingAccountById: jest.Mock;
+    lockConsumeAmount: jest.Mock;
+  };
+  let topcoderChallengesService: {
+    getChallengeById: jest.Mock;
   };
   let topcoderEngagementsService: {
     getAssignmentContextById: jest.Mock;
@@ -54,6 +64,9 @@ describe('WinningsService', () => {
 
   beforeEach(() => {
     tx = {
+      payment: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
       winnings: {
         create: jest.fn().mockResolvedValue({ winning_id: 'winning-1' }),
       },
@@ -70,6 +83,10 @@ describe('WinningsService', () => {
       getBillingAccountById: jest
         .fn()
         .mockResolvedValue({ id: 123456, markup: 0.2 }),
+      lockConsumeAmount: jest.fn().mockResolvedValue(undefined),
+    };
+    topcoderChallengesService = {
+      getChallengeById: jest.fn().mockResolvedValue(undefined),
     };
     topcoderEngagementsService = {
       getAssignmentContextById: jest.fn().mockResolvedValue({
@@ -88,6 +105,7 @@ describe('WinningsService', () => {
         completedIdentityVerification: jest.fn().mockResolvedValue(true),
       } as any,
       {} as any,
+      topcoderChallengesService as any,
       topcoderEngagementsService as any,
       billingAccountsService as any,
     );
@@ -420,5 +438,97 @@ describe('WinningsService', () => {
     expect(billingAccountsService.consumeAmounts).not.toHaveBeenCalled();
     expect(Number(persistedPayment.challenge_markup)).toBe(0.2);
     expect(Number(persistedPayment.challenge_fee)).toBe(20);
+  });
+
+  it('locks the aggregate billing-account amount for draft challenge payments', async () => {
+    topcoderChallengesService.getChallengeById.mockResolvedValue({
+      billing: {
+        markup: 0.2,
+      },
+      id: 'challenge-id',
+      status: 'DRAFT',
+    });
+    tx.payment.findMany.mockResolvedValue([
+      { total_amount: '100.00' },
+      { total_amount: '50.25' },
+    ]);
+
+    await service.createWinningWithPayments(
+      {
+        winnerId: 'user-1',
+        type: WinningsType.PAYMENT,
+        origin: 'Topcoder',
+        category: WinningsCategory.CONTEST_PAYMENT,
+        title: 'Draft challenge payment',
+        description: 'Draft challenge payment',
+        externalId: 'challenge-id',
+        details: [
+          {
+            totalAmount: 100,
+            grossAmount: 100,
+            installmentNumber: 1,
+            currency: PrizeType.USD,
+            billingAccount: '80001012',
+          },
+        ],
+      } as any,
+      'creator-1',
+    );
+
+    expect(topcoderChallengesService.getChallengeById).toHaveBeenCalledWith(
+      'challenge-id',
+    );
+    expect(tx.payment.findMany).toHaveBeenCalledWith({
+      select: { total_amount: true },
+      where: {
+        billing_account: '80001012',
+        currency: PrizeType.USD,
+        winnings: {
+          external_id: 'challenge-id',
+          type: 'PAYMENT',
+        },
+      },
+    });
+    expect(billingAccountsService.lockConsumeAmount).toHaveBeenCalledWith({
+      billingAccountId: 80001012,
+      challengeId: 'challenge-id',
+      markup: 0.2,
+      status: 'DRAFT',
+      totalPrizesInCents: 15025,
+    });
+  });
+
+  it('skips per-winning billing sync for generated challenge payment batches', async () => {
+    await service.createWinningWithPayments(
+      {
+        winnerId: 'user-1',
+        type: WinningsType.PAYMENT,
+        origin: 'Topcoder',
+        category: WinningsCategory.CONTEST_PAYMENT,
+        title: 'Generated challenge payment',
+        description: 'Generated challenge payment',
+        externalId: 'challenge-id',
+        attributes: {
+          billingAccountId: '80001012',
+          [CHALLENGE_BUDGET_SYNC_SKIP_ATTRIBUTE]: true,
+        },
+        details: [
+          {
+            totalAmount: 100,
+            grossAmount: 100,
+            installmentNumber: 1,
+            currency: PrizeType.USD,
+            billingAccount: '80001012',
+          },
+        ],
+      } as any,
+      'creator-1',
+    );
+
+    expect(topcoderChallengesService.getChallengeById).not.toHaveBeenCalled();
+    expect(billingAccountsService.lockConsumeAmount).not.toHaveBeenCalled();
+    expect(tx.winnings.create.mock.calls[0][0].data.attributes).toEqual({
+      billingAccountId: '80001012',
+    });
   });
 });

--- a/src/api/winnings/winnings.service.ts
+++ b/src/api/winnings/winnings.service.ts
@@ -35,10 +35,15 @@ import { IdentityVerificationRepository } from '../repository/identity-verificat
 import { PrizeType } from '../challenges/models';
 import { BillingAccountsService } from 'src/shared/topcoder/billing-accounts.service';
 import { TopcoderEngagementsService } from 'src/shared/topcoder/engagements.service';
+import {
+  TopcoderChallengeInfo,
+  TopcoderChallengesService,
+} from 'src/shared/topcoder/challenges.service';
 import { TopcoderM2MHttpError } from 'src/shared/topcoder/topcoder-m2m.service';
 
 const BUDGET_LEDGER_DECIMAL_PLACES = 4;
 const PAYMENT_DECIMAL_PLACES = 2;
+export const CHALLENGE_BUDGET_SYNC_SKIP_ATTRIBUTE = 'skipChallengeBudgetSync';
 
 interface EngagementBillingAccountConsume {
   amount: number;
@@ -51,6 +56,17 @@ interface EngagementBillingAccountConsumePlan {
   billingAccountId: number;
   challengeMarkup: number;
   consumes: EngagementBillingAccountConsume[];
+}
+
+interface ChallengeBillingAccountSync {
+  billingAccountId: number;
+  markup: number;
+}
+
+interface ChallengeBillingAccountSyncPlan {
+  billingAccounts: ChallengeBillingAccountSync[];
+  challengeId: string;
+  status: string;
 }
 
 /**
@@ -69,6 +85,7 @@ export class WinningsService {
    * @param tcMembersService Topcoder member profile client.
    * @param identityVerificationRepo repository for identity verification checks.
    * @param tcEmailService Topcoder email client.
+   * @param topcoderChallengesService Topcoder challenge client.
    * @param topcoderEngagementsService Topcoder engagements client.
    * @param billingAccountsService Topcoder billing-account client.
    */
@@ -80,13 +97,15 @@ export class WinningsService {
     private readonly tcMembersService: TopcoderMembersService,
     private readonly identityVerificationRepo: IdentityVerificationRepository,
     private readonly tcEmailService: TopcoderEmailService,
+    private readonly topcoderChallengesService: TopcoderChallengesService,
     private readonly topcoderEngagementsService: TopcoderEngagementsService,
     private readonly billingAccountsService: BillingAccountsService,
   ) {}
 
   /**
    * Builds the persisted winning attributes object.
-   * @param attributes Arbitrary attributes supplied by the client.
+   * @param attributes Arbitrary attributes supplied by the client. The internal
+   * challenge budget sync skip marker is removed before persistence.
    * @param hoursWorked Optional engagement-payment hours to persist.
    * @returns The normalized attributes object, or `undefined` when empty.
    */
@@ -98,6 +117,7 @@ export class WinningsService {
       attributes && typeof attributes === 'object' && !Array.isArray(attributes)
         ? { ...attributes }
         : {};
+    delete normalizedAttributes[CHALLENGE_BUDGET_SYNC_SKIP_ATTRIBUTE];
 
     if (hoursWorked !== undefined) {
       normalizedAttributes.hoursWorked = hoursWorked;
@@ -233,6 +253,239 @@ export class WinningsService {
     }
 
     return parsedBillingAccountId;
+  }
+
+  /**
+   * Checks whether the winning request opts out of per-winning challenge budget
+   * synchronization.
+   *
+   * @param body incoming winning creation request.
+   * @returns True when another caller will manage the aggregate challenge
+   * billing-account row.
+   */
+  private shouldSkipChallengeBudgetSync(
+    body: WinningCreateRequestDto,
+  ): boolean {
+    const attributes =
+      body.attributes &&
+      typeof body.attributes === 'object' &&
+      !Array.isArray(body.attributes)
+        ? (body.attributes as Record<string, unknown>)
+        : undefined;
+
+    return attributes?.[CHALLENGE_BUDGET_SYNC_SKIP_ATTRIBUTE] === true;
+  }
+
+  /**
+   * Normalizes the billing-account id from a challenge payment detail.
+   *
+   * @param detail payment detail supplied in the winning request.
+   * @param detailIndex zero-based detail index for error reporting.
+   * @returns positive integer billing account id.
+   * @throws BadRequestException when the detail cannot be mapped to an id.
+   */
+  private normalizeChallengeBillingAccountId(
+    detail: PaymentCreateRequestDto,
+    detailIndex: number,
+  ): number {
+    const rawBillingAccount = String(detail.billingAccount ?? '').trim();
+    const billingAccountId = Number(rawBillingAccount);
+
+    if (
+      !rawBillingAccount ||
+      !/^\d+$/.test(rawBillingAccount) ||
+      !Number.isSafeInteger(billingAccountId) ||
+      billingAccountId <= 0
+    ) {
+      throw new BadRequestException(
+        `details[${detailIndex}].billingAccount must be a valid billing account id`,
+      );
+    }
+
+    return billingAccountId;
+  }
+
+  /**
+   * Finds the distinct billing accounts touched by USD challenge payment details.
+   *
+   * @param body incoming winning creation request.
+   * @returns Unique positive billing-account ids from USD payment details.
+   * @throws BadRequestException when a USD detail has an invalid billing account.
+   */
+  private getChallengePaymentBillingAccountIds(
+    body: WinningCreateRequestDto,
+  ): number[] {
+    const billingAccountIds = new Set<number>();
+
+    for (const [detailIndex, detail] of (body.details || []).entries()) {
+      if (String(detail.currency) !== String(PrizeType.USD)) {
+        continue;
+      }
+
+      billingAccountIds.add(
+        this.normalizeChallengeBillingAccountId(detail, detailIndex),
+      );
+    }
+
+    return [...billingAccountIds];
+  }
+
+  /**
+   * Resolves the markup rate to use for a challenge billing-account sync.
+   *
+   * @param challenge challenge-api-v6 challenge details.
+   * @param billingAccountId billing account being synchronized.
+   * @returns Non-negative markup rate.
+   * @throws InternalServerErrorException when no valid markup can be resolved.
+   */
+  private async resolveChallengeBillingMarkup(
+    challenge: TopcoderChallengeInfo,
+    billingAccountId: number,
+  ): Promise<number> {
+    const candidateMarkups = [
+      challenge.billing?.clientBillingRate,
+      challenge.billing?.markup,
+    ];
+
+    for (const candidateMarkup of candidateMarkups) {
+      const markup = Number(candidateMarkup);
+
+      if (Number.isFinite(markup) && markup >= 0) {
+        return markup;
+      }
+    }
+
+    const billingAccount =
+      await this.billingAccountsService.getBillingAccountById(billingAccountId);
+
+    if (!Number.isFinite(billingAccount.markup) || billingAccount.markup < 0) {
+      throw new InternalServerErrorException(
+        `Billing account ${billingAccountId} has invalid markup`,
+      );
+    }
+
+    return billingAccount.markup;
+  }
+
+  /**
+   * Builds the challenge budget synchronization plan for a winning request.
+   *
+   * Finance only synchronizes non-engagement USD payment requests that point to
+   * an existing challenge. Challenge-generated payment batches set an internal
+   * skip marker because they already write one aggregate budget row after all
+   * generated payments are attempted.
+   *
+   * @param body incoming winning creation request.
+   * @returns Billing-account sync plan, or `undefined` when the request is not
+   * a challenge payment.
+   * @throws BadRequestException when a challenge payment detail has an invalid
+   * billing account.
+   * @throws InternalServerErrorException when markup cannot be resolved.
+   */
+  private async buildChallengeBillingAccountSyncPlan(
+    body: WinningCreateRequestDto,
+  ): Promise<ChallengeBillingAccountSyncPlan | undefined> {
+    const challengeId = String(body.externalId ?? '').trim();
+
+    if (
+      this.shouldSkipChallengeBudgetSync(body) ||
+      body.category === WinningsCategory.ENGAGEMENT_PAYMENT ||
+      body.type !== WinningsType.PAYMENT ||
+      !challengeId
+    ) {
+      return undefined;
+    }
+
+    const billingAccountIds = this.getChallengePaymentBillingAccountIds(body);
+
+    if (billingAccountIds.length === 0) {
+      return undefined;
+    }
+
+    const challenge =
+      await this.topcoderChallengesService.getChallengeById(challengeId);
+
+    if (!challenge?.id || !challenge.status) {
+      return undefined;
+    }
+
+    return {
+      billingAccounts: await Promise.all(
+        billingAccountIds.map(async (billingAccountId) => ({
+          billingAccountId,
+          markup: await this.resolveChallengeBillingMarkup(
+            challenge,
+            billingAccountId,
+          ),
+        })),
+      ),
+      challengeId,
+      status: challenge.status,
+    };
+  }
+
+  /**
+   * Sums persisted USD payment rows for a challenge and billing account.
+   *
+   * @param tx active Prisma transaction.
+   * @param challengeId challenge external id stored on winnings.
+   * @param billingAccountId billing account stored on payment rows.
+   * @returns Payment-scale total USD amount for all persisted challenge
+   * payments on that billing account.
+   */
+  private async getPersistedChallengePaymentTotal(
+    tx: Prisma.TransactionClient,
+    challengeId: string,
+    billingAccountId: number,
+  ): Promise<number> {
+    const payments = await tx.payment.findMany({
+      select: { total_amount: true },
+      where: {
+        billing_account: String(billingAccountId),
+        currency: PrizeType.USD,
+        winnings: {
+          external_id: challengeId,
+          type: winnings_type.PAYMENT,
+        },
+      },
+    });
+    const totalAmount = payments.reduce(
+      (sum, paymentRow) =>
+        sum.plus(new Prisma.Decimal(paymentRow.total_amount ?? 0)),
+      new Prisma.Decimal(0),
+    );
+
+    return this.toPaymentAmount(totalAmount);
+  }
+
+  /**
+   * Synchronizes challenge payment totals into billing-account locked/consumed rows.
+   *
+   * @param tx active Prisma transaction after the winning row has been created.
+   * @param syncPlan challenge billing-account sync plan.
+   * @returns Resolves when all affected billing accounts are synchronized.
+   */
+  private async syncChallengeBillingAccountBudget(
+    tx: Prisma.TransactionClient,
+    syncPlan: ChallengeBillingAccountSyncPlan,
+  ): Promise<void> {
+    await Promise.all(
+      syncPlan.billingAccounts.map(async ({ billingAccountId, markup }) => {
+        const totalUsdAmount = await this.getPersistedChallengePaymentTotal(
+          tx,
+          syncPlan.challengeId,
+          billingAccountId,
+        );
+
+        await this.billingAccountsService.lockConsumeAmount({
+          billingAccountId,
+          challengeId: syncPlan.challengeId,
+          markup,
+          status: syncPlan.status,
+          totalPrizesInCents: totalUsdAmount * 100,
+        });
+      }),
+    );
   }
 
   /**
@@ -751,13 +1004,16 @@ export class WinningsService {
    * Create winnings with parameters. Engagement payment requests derive
    * `payment.challenge_markup` and `payment.challenge_fee` from the trusted
    * project billing account and are gated by billing-account budget
-   * consumption before the transaction can complete.
+   * consumption before the transaction can complete. Challenge payment
+   * requests that point to a challenge synchronize the aggregate persisted USD
+   * payment total back to billing-account locked or consumed rows based on the
+   * current challenge status.
    *
    * @param body the request body
    * @param userId the request userId
    * @returns the Promise with response result
-   * @throws BadRequestException when engagement payment budget consume fails or
-   * engagement payment input is invalid.
+   * @throws BadRequestException when billing-account budget sync fails or
+   * payment input is invalid.
    */
   async createWinningWithPayments(
     body: WinningCreateRequestDto,
@@ -769,6 +1025,8 @@ export class WinningsService {
     const engagementConsumePlan = isEngagementPayment
       ? await this.buildEngagementBillingAccountConsumePlan(body)
       : undefined;
+    const challengeBillingAccountSyncPlan =
+      await this.buildChallengeBillingAccountSyncPlan(body);
     let setupEmailNotificationAmount: number | undefined;
 
     this.logger.debug(
@@ -977,6 +1235,13 @@ export class WinningsService {
 
       if (engagementConsumePlan) {
         await this.consumeEngagementBillingAccounts(engagementConsumePlan);
+      }
+
+      if (challengeBillingAccountSyncPlan) {
+        await this.syncChallengeBillingAccountBudget(
+          tx,
+          challengeBillingAccountSyncPlan,
+        );
       }
 
       if (

--- a/src/dto/winning.dto.ts
+++ b/src/dto/winning.dto.ts
@@ -173,7 +173,10 @@ export class WinningRequestDto extends SortPagination {
     description: 'Multiple winnings categories to filter by',
     enum: WinningsCategory,
     isArray: true,
-    example: [WinningsCategory.ENGAGEMENT_PAYMENT, WinningsCategory.TASK_PAYMENT],
+    example: [
+      WinningsCategory.ENGAGEMENT_PAYMENT,
+      WinningsCategory.TASK_PAYMENT,
+    ],
   })
   @IsOptional()
   @IsArray()

--- a/src/shared/access-control/access-control.service.spec.ts
+++ b/src/shared/access-control/access-control.service.spec.ts
@@ -30,9 +30,7 @@ describe('AccessControlService', () => {
       roleName: Role.PaymentAdmin,
       applyFilter: paymentAdminApplyFilter,
     };
-    const approverProvider: RoleAccessProvider<
-      Record<string, unknown>
-    > = {
+    const approverProvider: RoleAccessProvider<Record<string, unknown>> = {
       roleName: Role.PaymentApprover,
       applyFilter: approverApplyFilter,
     };
@@ -63,9 +61,7 @@ describe('AccessControlService', () => {
           categories: ['ENGAGEMENT_PAYMENT', 'TASK_PAYMENT'],
         }),
       );
-    const approverProvider: RoleAccessProvider<
-      Record<string, unknown>
-    > = {
+    const approverProvider: RoleAccessProvider<Record<string, unknown>> = {
       roleName: Role.PaymentApprover,
       applyFilter: approverApplyFilter,
     };

--- a/src/shared/topcoder/billing-accounts.service.spec.ts
+++ b/src/shared/topcoder/billing-accounts.service.spec.ts
@@ -1,0 +1,52 @@
+jest.mock('src/config', () => ({
+  ENV_CONFIG: {
+    TGBillingAccounts: [],
+    TOPCODER_API_V6_BASE_URL: 'https://api.topcoder-dev.com/v6',
+  },
+}));
+
+jest.mock('src/shared/global', () => ({
+  Logger: class {
+    error = jest.fn();
+
+    info = jest.fn();
+
+    log = jest.fn();
+
+    warn = jest.fn();
+  },
+}));
+
+import { ChallengeStatuses } from 'src/dto/challenge.dto';
+import { BillingAccountsService } from './billing-accounts.service';
+
+describe('BillingAccountsService', () => {
+  let service: BillingAccountsService;
+
+  beforeEach(() => {
+    service = new BillingAccountsService({} as any);
+  });
+
+  it('locks draft challenge funds until the challenge is completed', async () => {
+    const consumeAmountSpy = jest
+      .spyOn(service, 'consumeAmount')
+      .mockResolvedValue(undefined);
+    const lockAmountSpy = jest
+      .spyOn(service, 'lockAmount')
+      .mockResolvedValue(undefined);
+
+    await service.lockConsumeAmount({
+      billingAccountId: 80001012,
+      challengeId: 'challenge-id',
+      markup: 0.2,
+      status: ChallengeStatuses.Draft,
+      totalPrizesInCents: 25000,
+    });
+
+    expect(lockAmountSpy).toHaveBeenCalledWith(80001012, {
+      amount: 300,
+      challengeId: 'challenge-id',
+    });
+    expect(consumeAmountSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/topcoder/billing-accounts.service.ts
+++ b/src/shared/topcoder/billing-accounts.service.ts
@@ -10,6 +10,12 @@ import {
 
 const { TOPCODER_API_V6_BASE_URL, TGBillingAccounts } = ENV_CONFIG;
 
+const LOCKED_CHALLENGE_STATUSES = [
+  ChallengeStatuses.Draft,
+  ChallengeStatuses.Active,
+  ChallengeStatuses.Approved,
+].map((status) => status.toLowerCase());
+
 interface LockAmountDTO {
   challengeId: string;
   amount: number;
@@ -47,6 +53,19 @@ export interface BAValidation {
   status?: string;
   prevTotalPrizesInCents?: number;
   totalPrizesInCents: number;
+}
+
+/**
+ * Determines whether a challenge status should reserve billing-account budget
+ * without consuming it.
+ *
+ * @param status Challenge status received from challenge-api-v6.
+ * @returns True when finance should write the challenge amount as locked.
+ */
+function isLockedChallengeStatus(status?: string): boolean {
+  return status
+    ? LOCKED_CHALLENGE_STATUSES.includes(status.toLowerCase())
+    : false;
 }
 
 @Injectable()
@@ -329,10 +348,7 @@ export class BillingAccountsService {
     this.logger.log('BA validation:', baValidation);
 
     const status = baValidation.status?.toLowerCase();
-    if (
-      status === ChallengeStatuses.Active.toLowerCase() ||
-      status === ChallengeStatuses.Approved.toLowerCase()
-    ) {
+    if (isLockedChallengeStatus(status)) {
       // Update lock amount
       const currAmount = baValidation.totalPrizesInCents / 100;
       const prevAmount = (baValidation.prevTotalPrizesInCents ?? 0) / 100;

--- a/src/shared/topcoder/challenges.service.ts
+++ b/src/shared/topcoder/challenges.service.ts
@@ -20,10 +20,16 @@ export interface AdminPaymentUpdateData {
 }
 
 export interface TopcoderChallengeInfo {
+  billing?: {
+    billingAccountId?: number | string | null;
+    clientBillingRate?: number | string | null;
+    markup?: number | string | null;
+  };
+  createdBy?: string;
   id: string;
   name: string;
   projectId: number;
-  createdBy?: string;
+  status?: string;
 }
 
 export interface TopcoderProjectInfo {


### PR DESCRIPTION
What was broken
Payments created for challenges that were still in Draft did not create a locked billing-account budget row, so the Billing Account Details modal did not include those draft challenge payments as Locked.

Root cause (if identifiable)
The finance billing-account helper only treated Active and Approved challenges as lockable, and manual challenge payment creation did not synchronize the aggregate challenge payment total into the billing-account ledger.

What was changed
Draft challenges now use the locked budget path. Manual challenge payment creation resolves the challenge, aggregates persisted USD payments for that challenge and billing account, and writes the aggregate amount to the billing-account locked or consumed row based on the challenge status. Generated challenge payment batches mark their per-winning requests so the existing aggregate sync remains the single writer.

Any added/updated tests
Added coverage for Draft challenge budget locking and manual challenge payment budget sync. Updated challenge payment generation tests to assert the internal budget-sync skip marker.
