### PR TITLE
PM-4960: sync admin challenge payments to challenge BA

### DIFF
--- a/src/api/winnings/winnings.service.spec.ts
+++ b/src/api/winnings/winnings.service.spec.ts
@@ -440,6 +440,102 @@ describe('WinningsService', () => {
     expect(Number(persistedPayment.challenge_fee)).toBe(20);
   });
 
+  it('syncs completed challenge payments to the challenge billing account as consumed', async () => {
+    topcoderChallengesService.getChallengeById.mockResolvedValue({
+      billing: {
+        billingAccountId: '80001012',
+        markup: 0.2,
+      },
+      id: 'challenge-id',
+      status: 'COMPLETED',
+    });
+    tx.payment.findMany.mockResolvedValue([
+      { total_amount: '75.00' },
+      { total_amount: '25.00' },
+    ]);
+
+    await service.createWinningWithPayments(
+      {
+        winnerId: 'user-1',
+        type: WinningsType.PAYMENT,
+        origin: 'Topcoder',
+        category: WinningsCategory.CONTEST_PAYMENT,
+        title: 'Completed challenge payment',
+        description: 'Completed challenge payment',
+        externalId: 'challenge-id',
+        details: [
+          {
+            totalAmount: 25,
+            grossAmount: 25,
+            installmentNumber: 1,
+            currency: PrizeType.USD,
+            billingAccount: '80001012',
+          },
+        ],
+      } as any,
+      'creator-1',
+    );
+
+    expect(tx.payment.findMany).toHaveBeenCalledWith({
+      select: { total_amount: true },
+      where: {
+        billing_account: '80001012',
+        currency: PrizeType.USD,
+        winnings: {
+          external_id: 'challenge-id',
+          type: 'PAYMENT',
+        },
+      },
+    });
+    expect(billingAccountsService.lockConsumeAmount).toHaveBeenCalledWith({
+      billingAccountId: 80001012,
+      challengeId: 'challenge-id',
+      markup: 0.2,
+      status: 'COMPLETED',
+      totalPrizesInCents: 10000,
+    });
+  });
+
+  it('rejects manual challenge payments for a different billing account', async () => {
+    topcoderChallengesService.getChallengeById.mockResolvedValue({
+      billing: {
+        billingAccountId: '80001012',
+        markup: 0.2,
+      },
+      id: 'challenge-id',
+      status: 'COMPLETED',
+    });
+
+    await expect(
+      service.createWinningWithPayments(
+        {
+          winnerId: 'user-1',
+          type: WinningsType.PAYMENT,
+          origin: 'Topcoder',
+          category: WinningsCategory.CONTEST_PAYMENT,
+          title: 'Completed challenge payment',
+          description: 'Completed challenge payment',
+          externalId: 'challenge-id',
+          details: [
+            {
+              totalAmount: 25,
+              grossAmount: 25,
+              installmentNumber: 1,
+              currency: PrizeType.USD,
+              billingAccount: '999999',
+            },
+          ],
+        } as any,
+        'creator-1',
+      ),
+    ).rejects.toThrow(
+      'details[0].billingAccount does not match the challenge billing account',
+    );
+
+    expect(tx.winnings.create).not.toHaveBeenCalled();
+    expect(billingAccountsService.lockConsumeAmount).not.toHaveBeenCalled();
+  });
+
   it('locks the aggregate billing-account amount for draft challenge payments', async () => {
     topcoderChallengesService.getChallengeById.mockResolvedValue({
       billing: {

--- a/src/api/winnings/winnings.service.ts
+++ b/src/api/winnings/winnings.service.ts
@@ -331,6 +331,113 @@ export class WinningsService {
   }
 
   /**
+   * Normalizes the billing-account id configured on a challenge.
+   *
+   * @param billingAccountId raw challenge billing-account id.
+   * @param challengeId challenge id used in diagnostics.
+   * @returns positive integer billing-account id, or `undefined` when the
+   * challenge does not expose a configured billing account.
+   * @throws InternalServerErrorException when the configured billing-account id
+   * is malformed.
+   */
+  private normalizeConfiguredChallengeBillingAccountId(
+    billingAccountId: unknown,
+    challengeId: string,
+  ): number | undefined {
+    if (billingAccountId === undefined || billingAccountId === null) {
+      return undefined;
+    }
+
+    if (
+      typeof billingAccountId !== 'string' &&
+      typeof billingAccountId !== 'number'
+    ) {
+      throw new InternalServerErrorException(
+        `Challenge ${challengeId} billing account id has invalid type`,
+      );
+    }
+
+    const normalizedBillingAccountId = String(billingAccountId).trim();
+
+    if (!normalizedBillingAccountId) {
+      return undefined;
+    }
+
+    if (!/^\d+$/.test(normalizedBillingAccountId)) {
+      throw new InternalServerErrorException(
+        `Challenge ${challengeId} billing account id is invalid`,
+      );
+    }
+
+    const parsedBillingAccountId = Number(normalizedBillingAccountId);
+
+    if (
+      !Number.isSafeInteger(parsedBillingAccountId) ||
+      parsedBillingAccountId <= 0
+    ) {
+      throw new InternalServerErrorException(
+        `Challenge ${challengeId} billing account id is invalid`,
+      );
+    }
+
+    return parsedBillingAccountId;
+  }
+
+  /**
+   * Resolves the billing accounts that should be synchronized for a challenge
+   * payment request.
+   *
+   * When challenge-api exposes a challenge billing account, finance treats it
+   * as the source of truth and rejects caller-supplied payment details that
+   * target another account. Challenges without billing metadata keep the
+   * previous detail-based fallback.
+   *
+   * @param body incoming winning creation request.
+   * @param challenge challenge-api-v6 challenge details.
+   * @param detailBillingAccountIds billing-account ids supplied by USD payment
+   * details.
+   * @returns billing-account ids to synchronize for this challenge.
+   * @throws BadRequestException when a payment detail targets a different
+   * billing account than the challenge.
+   * @throws InternalServerErrorException when the challenge billing account id
+   * is malformed.
+   */
+  private getChallengeBillingAccountSyncIds(
+    body: WinningCreateRequestDto,
+    challenge: TopcoderChallengeInfo,
+    detailBillingAccountIds: number[],
+  ): number[] {
+    const configuredBillingAccountId =
+      this.normalizeConfiguredChallengeBillingAccountId(
+        challenge.billing?.billingAccountId,
+        String(challenge.id),
+      );
+
+    if (configuredBillingAccountId === undefined) {
+      return detailBillingAccountIds;
+    }
+
+    for (const [detailIndex, detail] of (body.details || []).entries()) {
+      if (String(detail.currency) !== String(PrizeType.USD)) {
+        continue;
+      }
+
+      const suppliedBillingAccountId = this.normalizeChallengeBillingAccountId(
+        detail,
+        detailIndex,
+      );
+
+      if (suppliedBillingAccountId !== configuredBillingAccountId) {
+        throw new BadRequestException(
+          `details[${detailIndex}].billingAccount does not match the challenge billing account`,
+        );
+      }
+    }
+
+    return [configuredBillingAccountId];
+  }
+
+  /**
    * Resolves the markup rate to use for a challenge billing-account sync.
    *
    * @param challenge challenge-api-v6 challenge details.
@@ -379,7 +486,8 @@ export class WinningsService {
    * @returns Billing-account sync plan, or `undefined` when the request is not
    * a challenge payment.
    * @throws BadRequestException when a challenge payment detail has an invalid
-   * billing account.
+   * billing account. When the challenge exposes a billing account, that account
+   * is used as the source of truth for the sync.
    * @throws InternalServerErrorException when markup cannot be resolved.
    */
   private async buildChallengeBillingAccountSyncPlan(
@@ -409,9 +517,15 @@ export class WinningsService {
       return undefined;
     }
 
+    const billingAccountSyncIds = this.getChallengeBillingAccountSyncIds(
+      body,
+      challenge,
+      billingAccountIds,
+    );
+
     return {
       billingAccounts: await Promise.all(
-        billingAccountIds.map(async (billingAccountId) => ({
+        billingAccountSyncIds.map(async (billingAccountId) => ({
           billingAccountId,
           markup: await this.resolveChallengeBillingMarkup(
             challenge,


### PR DESCRIPTION
What was broken
Payments added to completed challenges from system admin could create finance payment rows without guaranteeing the challenge billing account was the account synchronized back to billing accounts. That left the work app BA popup at risk of missing the added payment in consumed budget.

Root cause (if identifiable)
The manual /winnings challenge-payment path used the billing account supplied in the payment detail as the sync target, instead of treating the challenge billing account as the source of truth.

What was changed
Manual challenge payments now validate caller-supplied USD payment details against the challenge billing account when challenge-api exposes one, then synchronize the aggregate challenge payment total against that challenge billing account. Existing fallback behavior remains for challenge payloads that do not expose billing metadata.

Any added/updated tests
Added WinningsService coverage for completed challenge payments syncing to consumed challenge BA budget and for rejecting manual challenge payments that target a different billing account.

Validation
pnpm lint
pnpm test -- --runInBand
pnpm build
