### PR TITLE
PM-4958: Sync BA budget after payment cancellation

### DIFF
--- a/src/api/admin/admin.service.spec.ts
+++ b/src/api/admin/admin.service.spec.ts
@@ -45,19 +45,36 @@ jest.mock('src/shared/topcoder/challenges.service', () => ({
 }));
 
 import { AdminService } from './admin.service';
+import { PaymentStatus } from 'src/dto/payment.dto';
 
 describe('AdminService', () => {
   let service: AdminService;
   let prisma: {
+    $transaction: jest.Mock;
     audit: {
+      create: jest.Mock;
       findMany: jest.Mock;
+    };
+    payment: {
+      findMany: jest.Mock;
+      update: jest.Mock;
+    };
+    payment_releases: {
+      findFirst: jest.Mock;
+      updateMany: jest.Mock;
     };
     winnings: {
       findFirst: jest.Mock;
     };
   };
-  let paymentsService: object;
-  let baService: object;
+  let paymentsService: {
+    reconcileUserPayments: jest.Mock;
+  };
+  let baService: {
+    getBillingAccountById: jest.Mock;
+    getBillingAccountsForUser: jest.Mock;
+    lockConsumeAmount: jest.Mock;
+  };
   let accessControlService: {
     verifyAccess: jest.Mock;
   };
@@ -75,15 +92,35 @@ describe('AdminService', () => {
 
   beforeEach(() => {
     prisma = {
+      $transaction: jest.fn((callback: (tx: unknown) => unknown) =>
+        Promise.resolve(callback(prisma)),
+      ),
       audit: {
+        create: jest.fn().mockResolvedValue({}),
         findMany: jest.fn().mockResolvedValue([]),
+      },
+      payment: {
+        findMany: jest.fn().mockResolvedValue([]),
+        update: jest.fn().mockResolvedValue({}),
+      },
+      payment_releases: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
       },
       winnings: {
         findFirst: jest.fn(),
       },
     };
-    paymentsService = {};
-    baService = {};
+    paymentsService = {
+      reconcileUserPayments: jest.fn().mockResolvedValue(undefined),
+    };
+    baService = {
+      getBillingAccountById: jest
+        .fn()
+        .mockResolvedValue({ id: 80001012, markup: 0.1 }),
+      getBillingAccountsForUser: jest.fn().mockResolvedValue(['80001012']),
+      lockConsumeAmount: jest.fn().mockResolvedValue(undefined),
+    };
     accessControlService = {
       verifyAccess: jest.fn().mockResolvedValue(undefined),
     };
@@ -341,6 +378,83 @@ describe('AdminService', () => {
     await expect(
       service.getWinningPaymentDetails('missing-winning', '123456', []),
     ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('recalculates the challenge billing-account line item when a challenge payment is cancelled', async () => {
+    prisma.payment.findMany
+      .mockResolvedValueOnce([
+        {
+          billing_account: '80001012',
+          currency: 'USD',
+          installment_number: 1,
+          payment_id: 'payment-1',
+          payment_status: PaymentStatus.OWED,
+          release_date: new Date('2026-04-27T00:00:00.000Z'),
+          version: 1,
+          winnings: {
+            category: 'CONTEST_PAYMENT',
+            external_id: 'challenge-1',
+            type: 'PAYMENT',
+          },
+        },
+      ])
+      .mockResolvedValueOnce([
+        { total_amount: '12.00' },
+        { total_amount: '27.50' },
+      ]);
+    topcoderChallengesService.getChallengeById.mockResolvedValue({
+      billing: {
+        billingAccountId: '80001012',
+        markup: 0.1,
+      },
+      id: 'challenge-1',
+      status: 'COMPLETED',
+    });
+
+    const result = await service.updateWinnings(
+      {
+        paymentId: 'payment-1',
+        paymentStatus: PaymentStatus.CANCELLED,
+        winningsId: 'winning-1',
+      } as any,
+      'admin-1',
+      ['Payment Admin'],
+    );
+
+    expect(result.data).toBe('Successfully updated winnings');
+    expect(prisma.payment.update).toHaveBeenCalledWith({
+      where: {
+        payment_id: 'payment-1',
+        winnings_id: 'winning-1',
+        version: 1,
+      },
+      data: {
+        date_paid: undefined,
+        payment_status: PaymentStatus.CANCELLED,
+        updated_at: expect.any(Date),
+        updated_by: 'admin-1',
+        version: 2,
+      },
+    });
+    expect(prisma.payment.findMany).toHaveBeenNthCalledWith(2, {
+      select: { total_amount: true },
+      where: {
+        billing_account: '80001012',
+        currency: 'USD',
+        payment_status: { not: PaymentStatus.CANCELLED },
+        winnings: {
+          external_id: 'challenge-1',
+          type: 'PAYMENT',
+        },
+      },
+    });
+    expect(baService.lockConsumeAmount).toHaveBeenCalledWith({
+      billingAccountId: 80001012,
+      challengeId: 'challenge-1',
+      markup: 0.1,
+      status: 'COMPLETED',
+      totalPrizesInCents: 3950,
+    });
   });
 
   it('returns task details for task payment with projectId and approver', async () => {

--- a/src/api/admin/admin.service.ts
+++ b/src/api/admin/admin.service.ts
@@ -6,13 +6,19 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 
-import { Prisma } from '@prisma/client';
+import {
+  Prisma,
+  payment_status,
+  winnings_category,
+  winnings_type,
+} from '@prisma/client';
 import { PrismaService } from 'src/shared/global/prisma.service';
 import { PaymentsService } from 'src/shared/payments';
 import { AccessControlService } from 'src/shared/access-control/access-control.service';
 
 import { ResponseDto } from 'src/dto/api-response.dto';
 import { PaymentStatus } from 'src/dto/payment.dto';
+import { PrizeType } from '../challenges/models';
 import { WinningAuditDto, AuditPayoutDto } from './dto/audit.dto';
 import { WinningUpdateRequestDto } from './dto/winnings.dto';
 import { Logger } from 'src/shared/global';
@@ -23,8 +29,18 @@ import {
   TopcoderEngagementsService,
 } from 'src/shared/topcoder/engagements.service';
 import { TopcoderMembersService } from 'src/shared/topcoder/members.service';
-import { TopcoderChallengesService } from 'src/shared/topcoder/challenges.service';
+import {
+  TopcoderChallengeInfo,
+  TopcoderChallengesService,
+} from 'src/shared/topcoder/challenges.service';
 import { WinningPaymentDetailsDto } from './dto/payment-details.dto';
+
+const PAYMENT_DECIMAL_PLACES = 2;
+
+interface ChallengeBudgetSyncTarget {
+  billingAccountId: number;
+  challengeId: string;
+}
 
 /**
  * The admin winning service.
@@ -292,6 +308,246 @@ export class AdminService {
   }
 
   /**
+   * Normalizes billing-account identifiers read from persisted payment or
+   * challenge records.
+   *
+   * @param billingAccountId raw billing-account id value.
+   * @returns positive integer billing-account id, or `undefined` when the value
+   * is missing or malformed.
+   * @throws This helper does not throw.
+   */
+  private normalizeBillingAccountId(
+    billingAccountId: unknown,
+  ): number | undefined {
+    if (billingAccountId === undefined || billingAccountId === null) {
+      return undefined;
+    }
+
+    if (
+      typeof billingAccountId !== 'string' &&
+      typeof billingAccountId !== 'number'
+    ) {
+      return undefined;
+    }
+
+    const normalizedBillingAccountId = String(billingAccountId).trim();
+    const parsedBillingAccountId = Number(normalizedBillingAccountId);
+
+    if (
+      !normalizedBillingAccountId ||
+      !/^\d+$/.test(normalizedBillingAccountId) ||
+      !Number.isSafeInteger(parsedBillingAccountId) ||
+      parsedBillingAccountId <= 0
+    ) {
+      return undefined;
+    }
+
+    return parsedBillingAccountId;
+  }
+
+  /**
+   * Finds challenge billing-account rows that need to be recalculated after a
+   * wallet-admin payment status change.
+   *
+   * @param payments payment rows selected by the update request.
+   * @returns unique challenge and billing-account pairs touched by USD
+   * challenge payments.
+   * @throws This helper does not throw.
+   */
+  private getChallengeBudgetSyncTargets(
+    payments: Awaited<ReturnType<AdminService['getPaymentsByWinningsId']>>,
+  ): ChallengeBudgetSyncTarget[] {
+    const targets = new Map<string, ChallengeBudgetSyncTarget>();
+
+    payments.forEach((payment) => {
+      const challengeId =
+        typeof payment.winnings.external_id === 'string'
+          ? payment.winnings.external_id.trim()
+          : '';
+
+      if (
+        !challengeId ||
+        payment.winnings.type !== winnings_type.PAYMENT ||
+        payment.winnings.category === winnings_category.ENGAGEMENT_PAYMENT ||
+        (payment.currency ?? '') !== 'USD'
+      ) {
+        return;
+      }
+
+      const billingAccountId = this.normalizeBillingAccountId(
+        payment.billing_account,
+      );
+
+      if (!billingAccountId) {
+        this.logger.warn(
+          `Skipping challenge budget sync for payment ${payment.payment_id}; invalid billing account ${String(payment.billing_account)}`,
+        );
+        return;
+      }
+
+      targets.set(`${challengeId}:${billingAccountId}`, {
+        billingAccountId,
+        challengeId,
+      });
+    });
+
+    return [...targets.values()];
+  }
+
+  /**
+   * Resolves the billing account to synchronize for a challenge.
+   *
+   * @param challenge challenge-api-v6 payload.
+   * @param fallbackBillingAccountId billing account from the payment row when
+   * challenge metadata does not expose one.
+   * @returns the configured challenge billing account when available, otherwise
+   * the payment-row billing account.
+   * @throws This helper does not throw.
+   */
+  private resolveChallengeBudgetBillingAccountId(
+    challenge: TopcoderChallengeInfo,
+    fallbackBillingAccountId: number,
+  ): number {
+    return (
+      this.normalizeBillingAccountId(challenge.billing?.billingAccountId) ??
+      fallbackBillingAccountId
+    );
+  }
+
+  /**
+   * Resolves the markup used when writing a challenge budget line item.
+   *
+   * @param challenge challenge-api-v6 payload.
+   * @param billingAccountId billing account being synchronized.
+   * @returns non-negative markup rate.
+   * @throws Error when no valid markup can be resolved.
+   */
+  private async resolveChallengeBudgetMarkup(
+    challenge: TopcoderChallengeInfo,
+    billingAccountId: number,
+  ): Promise<number> {
+    const candidateMarkups = [
+      challenge.billing?.clientBillingRate,
+      challenge.billing?.markup,
+    ];
+
+    for (const candidateMarkup of candidateMarkups) {
+      const markup = Number(candidateMarkup);
+
+      if (Number.isFinite(markup) && markup >= 0) {
+        return markup;
+      }
+    }
+
+    const billingAccount =
+      await this.baService.getBillingAccountById(billingAccountId);
+
+    if (!Number.isFinite(billingAccount.markup) || billingAccount.markup < 0) {
+      throw new Error(`Billing account ${billingAccountId} has invalid markup`);
+    }
+
+    return billingAccount.markup;
+  }
+
+  /**
+   * Quantizes a payment total to the same two-decimal scale used by persisted
+   * payment rows.
+   *
+   * @param amount decimal amount to normalize.
+   * @returns JavaScript number rounded to two decimal places.
+   * @throws This helper does not throw.
+   */
+  private toPaymentAmount(amount: Prisma.Decimal): number {
+    return Number(
+      amount
+        .toDecimalPlaces(PAYMENT_DECIMAL_PLACES, Prisma.Decimal.ROUND_HALF_UP)
+        .toFixed(PAYMENT_DECIMAL_PLACES),
+    );
+  }
+
+  /**
+   * Sums non-cancelled USD payment rows for a challenge and billing account.
+   *
+   * @param challengeId challenge external id stored on winnings.
+   * @param billingAccountId billing account stored on payment rows.
+   * @returns total member-payment amount that should remain locked or consumed
+   * for the challenge billing-account line item.
+   * @throws Prisma errors when the aggregate query fails.
+   */
+  private async getActiveChallengePaymentTotal(
+    challengeId: string,
+    billingAccountId: number,
+  ): Promise<number> {
+    const payments = await this.prisma.payment.findMany({
+      select: { total_amount: true },
+      where: {
+        billing_account: String(billingAccountId),
+        currency: PrizeType.USD,
+        payment_status: { not: payment_status.CANCELLED },
+        winnings: {
+          external_id: challengeId,
+          type: 'PAYMENT',
+        },
+      },
+    });
+    const totalAmount = payments.reduce(
+      (sum, paymentRow) =>
+        sum.plus(new Prisma.Decimal(paymentRow.total_amount ?? 0)),
+      new Prisma.Decimal(0),
+    );
+
+    return this.toPaymentAmount(totalAmount);
+  }
+
+  /**
+   * Rewrites challenge billing-account budget rows after a wallet-admin status
+   * update changes the active payment total.
+   *
+   * @param targets unique challenge and billing-account pairs to synchronize.
+   * @returns promise resolved after every target has been sent to BA.
+   * @throws Error when BA synchronization fails.
+   */
+  private async syncChallengeBudgetTargets(
+    targets: ChallengeBudgetSyncTarget[],
+  ): Promise<void> {
+    await Promise.all(
+      targets.map(async (target) => {
+        const challenge = await this.topcoderChallengesService.getChallengeById(
+          target.challengeId,
+        );
+
+        if (!challenge?.id || !challenge.status) {
+          this.logger.warn(
+            `Skipping challenge budget sync for ${target.challengeId}; challenge metadata is unavailable`,
+          );
+          return;
+        }
+
+        const billingAccountId = this.resolveChallengeBudgetBillingAccountId(
+          challenge,
+          target.billingAccountId,
+        );
+        const markup = await this.resolveChallengeBudgetMarkup(
+          challenge,
+          billingAccountId,
+        );
+        const totalUsdAmount = await this.getActiveChallengePaymentTotal(
+          target.challengeId,
+          billingAccountId,
+        );
+
+        await this.baService.lockConsumeAmount({
+          billingAccountId,
+          challengeId: target.challengeId,
+          markup,
+          status: challenge.status,
+          totalPrizesInCents: totalUsdAmount * 100,
+        });
+      }),
+    );
+  }
+
+  /**
    * Verify that a BA admin user has access to the billing account(s)
    * associated with the given winningsId. Throws BadRequestException when
    * access is not allowed.
@@ -382,6 +638,10 @@ export class AdminService {
         tx: Prisma.TransactionClient,
       ) => Promise<unknown>)[] = [];
       const now = new Date().getTime();
+      const challengeBudgetSyncTargets =
+        body.paymentStatus === PaymentStatus.CANCELLED
+          ? this.getChallengeBudgetSyncTargets(payments)
+          : [];
 
       // iterate payments and build transaction list
       payments.forEach((payment) => {
@@ -663,6 +923,10 @@ export class AdminService {
       this.logger.log(
         `Successfully executed transactions for winningsId=${winningsId}`,
       );
+
+      if (challengeBudgetSyncTargets.length > 0) {
+        await this.syncChallengeBudgetTargets(challengeBudgetSyncTargets);
+      }
 
       if (needsReconciliation) {
         const winning = await this.prisma.winnings.findFirst({

--- a/src/api/winnings/winnings.service.spec.ts
+++ b/src/api/winnings/winnings.service.spec.ts
@@ -483,6 +483,7 @@ describe('WinningsService', () => {
       where: {
         billing_account: '80001012',
         currency: PrizeType.USD,
+        payment_status: { not: 'CANCELLED' },
         winnings: {
           external_id: 'challenge-id',
           type: 'PAYMENT',

--- a/src/api/winnings/winnings.service.ts
+++ b/src/api/winnings/winnings.service.ts
@@ -425,13 +425,14 @@ export class WinningsService {
   }
 
   /**
-   * Sums persisted USD payment rows for a challenge and billing account.
+   * Sums non-cancelled persisted USD payment rows for a challenge and billing
+   * account.
    *
    * @param tx active Prisma transaction.
    * @param challengeId challenge external id stored on winnings.
    * @param billingAccountId billing account stored on payment rows.
-   * @returns Payment-scale total USD amount for all persisted challenge
-   * payments on that billing account.
+   * @returns Payment-scale total USD amount for active challenge payments on
+   * that billing account.
    */
   private async getPersistedChallengePaymentTotal(
     tx: Prisma.TransactionClient,
@@ -443,6 +444,7 @@ export class WinningsService {
       where: {
         billing_account: String(billingAccountId),
         currency: PrizeType.USD,
+        payment_status: { not: payment_status.CANCELLED },
         winnings: {
           external_id: challengeId,
           type: winnings_type.PAYMENT,


### PR DESCRIPTION
What was broken
Cancelling a challenge payment in wallet-admin only changed the finance payment status. The billing account consumed line item for the challenge external ID still included the cancelled payment amount.

Root cause (if identifiable)
The admin update path did not recalculate or overwrite the challenge billing-account budget row after moving a payment to CANCELLED. The existing challenge budget total query also counted cancelled payment rows.

What was changed
Added challenge budget synchronization to the admin cancellation flow so BA receives the remaining non-cancelled USD payment total for the affected challenge and billing account. Updated challenge budget total queries to exclude CANCELLED payments.

Any added/updated tests
Added an AdminService cancellation test covering BA resync after a challenge payment is cancelled. Updated the WinningsService budget sync expectation to exclude CANCELLED rows.
