### PR TITLE
PM-4957: Fix cancelled challenge budget sync

### DIFF
--- a/src/api/challenges/challenges.service.spec.ts
+++ b/src/api/challenges/challenges.service.spec.ts
@@ -254,4 +254,112 @@ describe('ChallengesService', () => {
       }),
     ]);
   });
+
+  it('skips winner payments for cancelled challenges', () => {
+    const service = new ChallengesService(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+
+    const payments = service.generateWinnersPayments(
+      {
+        name: 'Cancelled Challenge',
+        status: ChallengeStatuses.CancelledClientRequest,
+        task: { isTask: false },
+        type: 'Challenge',
+      } as any,
+      [{ handle: 'winner', placement: 1, userId: 40158994 }],
+      [{ type: PrizeType.USD, value: 500 }],
+    );
+
+    expect(payments).toEqual([]);
+  });
+
+  it('skips copilot payments for cancelled challenges', () => {
+    const service = new ChallengesService(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+
+    const payments = service.generateCopilotPayment(
+      {
+        id: '11111111-1111-1111-1111-111111111111',
+        name: 'Cancelled Challenge',
+        prizeSets: [
+          { prizes: [{ type: PrizeType.USD, value: 100 }], type: 'COPILOT' },
+          { prizes: [{ type: PrizeType.USD, value: 500 }], type: 'PLACEMENT' },
+        ],
+        status: ChallengeStatuses.CancelledClientRequest,
+      } as any,
+      [{ memberHandle: 'copilot', memberId: '40158994' }] as any,
+    );
+
+    expect(payments).toEqual([]);
+  });
+
+  it('allows cancelled challenges with no generated payments to release budget locks', async () => {
+    const prisma = {
+      challenge_lock: {
+        create: jest.fn().mockResolvedValue({}),
+        deleteMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+    };
+    const baService = {
+      lockConsumeAmount: jest.fn().mockResolvedValue(undefined),
+    };
+    const winningsService = {
+      createWinningWithPayments: jest.fn(),
+    };
+    const winningsRepo = {
+      searchWinnings: jest.fn().mockResolvedValue({ data: { winnings: [] } }),
+    };
+    const service = new ChallengesService(
+      prisma as any,
+      {} as any,
+      baService as any,
+      winningsService as any,
+      winningsRepo as any,
+    );
+    const challenge = {
+      billing: { billingAccountId: '80001012', markup: 0.1 },
+      funChallenge: false,
+      id: '11111111-1111-1111-1111-111111111111',
+      name: 'Cancelled Challenge',
+      prizeSets: [
+        { prizes: [{ type: PrizeType.USD, value: 500 }], type: 'PLACEMENT' },
+      ],
+      reviewers: [],
+      status: ChallengeStatuses.CancelledClientRequest,
+      task: { isTask: false },
+      type: 'Challenge',
+    };
+
+    jest.spyOn(service, 'getChallenge').mockResolvedValue(challenge as any);
+    jest.spyOn(service, 'getChallengeResources').mockResolvedValue({
+      reviewer: [{ memberHandle: 'reviewer', memberId: '40158995' }],
+    } as any);
+    jest.spyOn(service, 'getChallengeReviews').mockResolvedValue([]);
+
+    await service.generateChallengePayments(
+      '11111111-1111-1111-1111-111111111111',
+      'test-user',
+    );
+
+    expect(winningsService.createWinningWithPayments).not.toHaveBeenCalled();
+    expect(baService.lockConsumeAmount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        billingAccountId: 80001012,
+        challengeId: '11111111-1111-1111-1111-111111111111',
+        markup: 0.1,
+        status: ChallengeStatuses.CancelledClientRequest,
+        totalPrizesInCents: 0,
+      }),
+    );
+  });
 });

--- a/src/api/challenges/challenges.service.ts
+++ b/src/api/challenges/challenges.service.ts
@@ -64,7 +64,32 @@ const PAYMENT_TYPE_TO_CATEGORY: Record<string, WinningsCategory> = {
   topgear: WinningsCategory.TOPGEAR_PAYMENT,
 };
 
+const CANCELLED_CHALLENGE_STATUSES = [
+  ChallengeStatuses.Canceled,
+  ChallengeStatuses.CancelledFailedReview,
+  ChallengeStatuses.CancelledFailedScreening,
+  ChallengeStatuses.CancelledZeroSubmissions,
+  ChallengeStatuses.CancelledWinnerUnresponsive,
+  ChallengeStatuses.CancelledClientRequest,
+  ChallengeStatuses.CancelledRequirementsInfeasible,
+  ChallengeStatuses.CancelledZeroRegistrations,
+  ChallengeStatuses.CancelledPaymentFailed,
+].map((status) => status.toLowerCase());
+
 const { TOPCODER_API_V6_BASE_URL: TC_API_BASE, TGBillingAccounts } = ENV_CONFIG;
+
+/**
+ * Determines whether a challenge status represents a cancelled challenge.
+ *
+ * @param status Challenge status returned by challenge-api-v6.
+ * @returns True when the status is one of the cancelled challenge states used
+ * by challenge-api-v6.
+ */
+function isCancelledChallengeStatus(status?: string): boolean {
+  return status
+    ? CANCELLED_CHALLENGE_STATUSES.includes(status.toLowerCase())
+    : false;
+}
 
 @Injectable()
 export class ChallengesService {
@@ -194,11 +219,7 @@ export class ChallengesService {
     prizes: Prize[],
     type?: WinningsCategory,
   ): PaymentPayload[] {
-    const isCancelledFailedReview =
-      challenge.status.toLowerCase() ===
-      ChallengeStatuses.CancelledFailedReview.toLowerCase();
-
-    if (isCancelledFailedReview) {
+    if (isCancelledChallengeStatus(challenge.status)) {
       return [];
     }
 
@@ -285,14 +306,10 @@ export class ChallengesService {
     challenge: Challenge,
     copilots: ChallengeResource[],
   ): PaymentPayload[] {
-    const isCancelledFailedReview =
-      challenge.status.toLowerCase() ===
-      ChallengeStatuses.CancelledFailedReview.toLowerCase();
-
     const copilotPrizes =
       find(challenge.prizeSets, { type: 'COPILOT' })?.prizes ?? [];
 
-    if (!copilotPrizes.length || isCancelledFailedReview) {
+    if (!copilotPrizes.length || isCancelledChallengeStatus(challenge.status)) {
       return [];
     }
 
@@ -625,12 +642,12 @@ export class ChallengesService {
       `Challenge ${challenge.id} - "${challenge.name}" with status "${challenge.status}" retrieved`,
     );
 
-    const allowedStatuses = [
-      ChallengeStatuses.Completed.toLowerCase(),
-      ChallengeStatuses.CancelledFailedReview.toLowerCase(),
-    ];
+    const isPayableStatus =
+      challenge.status.toLowerCase() ===
+        ChallengeStatuses.Completed.toLowerCase() ||
+      isCancelledChallengeStatus(challenge.status);
 
-    if (!allowedStatuses.includes(challenge.status.toLowerCase())) {
+    if (!isPayableStatus) {
       this.logger.error(
         `Challenge ${challenge.id} isn't in a payable status: ${challenge.status}`,
       );

--- a/src/shared/topcoder/billing-accounts.service.spec.ts
+++ b/src/shared/topcoder/billing-accounts.service.spec.ts
@@ -49,4 +49,50 @@ describe('BillingAccountsService', () => {
     });
     expect(consumeAmountSpy).not.toHaveBeenCalled();
   });
+
+  it('consumes cancelled challenge funds when generated payments exist', async () => {
+    const consumeAmountSpy = jest
+      .spyOn(service, 'consumeAmount')
+      .mockResolvedValue(undefined);
+    const lockAmountSpy = jest
+      .spyOn(service, 'lockAmount')
+      .mockResolvedValue(undefined);
+
+    await service.lockConsumeAmount({
+      billingAccountId: 80001012,
+      challengeId: 'challenge-id',
+      markup: 0.2,
+      status: ChallengeStatuses.CancelledFailedReview,
+      totalPrizesInCents: 25000,
+    });
+
+    expect(consumeAmountSpy).toHaveBeenCalledWith(80001012, {
+      amount: 300,
+      challengeId: 'challenge-id',
+    });
+    expect(lockAmountSpy).not.toHaveBeenCalled();
+  });
+
+  it('unlocks cancelled challenge funds when no payments exist', async () => {
+    const consumeAmountSpy = jest
+      .spyOn(service, 'consumeAmount')
+      .mockResolvedValue(undefined);
+    const lockAmountSpy = jest
+      .spyOn(service, 'lockAmount')
+      .mockResolvedValue(undefined);
+
+    await service.lockConsumeAmount({
+      billingAccountId: 80001012,
+      challengeId: 'challenge-id',
+      markup: 0.2,
+      status: ChallengeStatuses.CancelledClientRequest,
+      totalPrizesInCents: 0,
+    });
+
+    expect(lockAmountSpy).toHaveBeenCalledWith(80001012, {
+      amount: 0,
+      challengeId: 'challenge-id',
+    });
+    expect(consumeAmountSpy).not.toHaveBeenCalled();
+  });
 });

--- a/src/shared/topcoder/billing-accounts.service.ts
+++ b/src/shared/topcoder/billing-accounts.service.ts
@@ -16,6 +16,19 @@ const LOCKED_CHALLENGE_STATUSES = [
   ChallengeStatuses.Approved,
 ].map((status) => status.toLowerCase());
 
+const CANCELLED_CHALLENGE_STATUSES = [
+  ChallengeStatuses.Deleted,
+  ChallengeStatuses.Canceled,
+  ChallengeStatuses.CancelledFailedReview,
+  ChallengeStatuses.CancelledFailedScreening,
+  ChallengeStatuses.CancelledZeroSubmissions,
+  ChallengeStatuses.CancelledWinnerUnresponsive,
+  ChallengeStatuses.CancelledClientRequest,
+  ChallengeStatuses.CancelledRequirementsInfeasible,
+  ChallengeStatuses.CancelledZeroRegistrations,
+  ChallengeStatuses.CancelledPaymentFailed,
+].map((status) => status.toLowerCase());
+
 interface LockAmountDTO {
   challengeId: string;
   amount: number;
@@ -65,6 +78,18 @@ export interface BAValidation {
 function isLockedChallengeStatus(status?: string): boolean {
   return status
     ? LOCKED_CHALLENGE_STATUSES.includes(status.toLowerCase())
+    : false;
+}
+
+/**
+ * Determines whether a challenge status represents a cancelled terminal state.
+ *
+ * @param status Challenge status received from challenge-api-v6.
+ * @returns True when finance should release or consume any challenge budget row.
+ */
+function isCancelledChallengeStatus(status?: string): boolean {
+  return status
+    ? CANCELLED_CHALLENGE_STATUSES.includes(status.toLowerCase())
     : false;
 }
 
@@ -373,34 +398,21 @@ export class BillingAccountsService {
             (rollback ? prevAmount : currAmount) * (1 + baValidation.markup!),
         });
       }
-    } else if (
-      [
-        ChallengeStatuses.Deleted,
-        ChallengeStatuses.Canceled,
-        ChallengeStatuses.CancelledFailedReview,
-        ChallengeStatuses.CancelledFailedScreening,
-        ChallengeStatuses.CancelledZeroSubmissions,
-        ChallengeStatuses.CancelledWinnerUnresponsive,
-        ChallengeStatuses.CancelledClientRequest,
-        ChallengeStatuses.CancelledRequirementsInfeasible,
-        ChallengeStatuses.CancelledZeroRegistrations,
-        ChallengeStatuses.CancelledPaymentFailed,
-      ].some((t) => t.toLowerCase() === status)
-    ) {
-      if (
-        baValidation.prevStatus?.toLowerCase() ===
-        ChallengeStatuses.Active.toLowerCase()
-      ) {
-        // Challenge canceled, unlock previous locked amount
-        const currAmount = 0;
-        const prevAmount = (baValidation.prevTotalPrizesInCents ?? 0) / 100;
+    } else if (isCancelledChallengeStatus(status)) {
+      const currAmount = baValidation.totalPrizesInCents / 100;
+      const prevAmount = (baValidation.prevTotalPrizesInCents ?? 0) / 100;
+      const targetAmount = rollback ? prevAmount : currAmount;
 
-        if (currAmount !== prevAmount) {
-          await this.lockAmount(billingAccountId, {
-            challengeId: baValidation.challengeId!,
-            amount: rollback ? prevAmount : 0,
-          });
-        }
+      if (targetAmount > 0) {
+        await this.consumeAmount(billingAccountId, {
+          challengeId: baValidation.challengeId!,
+          amount: targetAmount * (1 + baValidation.markup!),
+        });
+      } else {
+        await this.lockAmount(billingAccountId, {
+          challengeId: baValidation.challengeId!,
+          amount: 0,
+        });
       }
     }
   }


### PR DESCRIPTION
What was broken
Cancelled challenge payment generation only treated CANCELLED_FAILED_REVIEW as payable, and cancelled budget sync only unlocked prior active locks. Cancelled challenges with reviewer payments could leave budget locked instead of consumed, while cancelled challenges with no payments did not reliably clear the lock.

Root cause
Finance keyed cancelled budget handling on the previous ACTIVE status instead of the aggregate generated payment total, and challenge payment generation did not accept all cancelled terminal statuses.

What was changed
Allowed cancelled challenge statuses through payment generation, while skipping winner and copilot payments so cancelled challenges only generate eligible reviewer payments. Updated billing-account synchronization so cancelled challenges with generated payment totals consume the budget, while cancelled challenges with a zero generated total unlock the budget.

Any added/updated tests
Added challenge service tests for cancelled winner and copilot skips plus zero-payment lock release. Added billing account service tests for cancelled generated-payment consumption and zero-payment unlock behavior.

Validation
pnpm test
pnpm lint
pnpm build
