### PR TITLE
PM-4958: Release engagement BA consumption on cancellation

### DIFF
--- a/src/api/admin/admin.service.spec.ts
+++ b/src/api/admin/admin.service.spec.ts
@@ -74,6 +74,7 @@ describe('AdminService', () => {
     getBillingAccountById: jest.Mock;
     getBillingAccountsForUser: jest.Mock;
     lockConsumeAmount: jest.Mock;
+    syncEngagementConsumeAmounts: jest.Mock;
   };
   let accessControlService: {
     verifyAccess: jest.Mock;
@@ -120,6 +121,7 @@ describe('AdminService', () => {
         .mockResolvedValue({ id: 80001012, markup: 0.1 }),
       getBillingAccountsForUser: jest.fn().mockResolvedValue(['80001012']),
       lockConsumeAmount: jest.fn().mockResolvedValue(undefined),
+      syncEngagementConsumeAmounts: jest.fn().mockResolvedValue(undefined),
     };
     accessControlService = {
       verifyAccess: jest.fn().mockResolvedValue(undefined),
@@ -455,6 +457,62 @@ describe('AdminService', () => {
       status: 'COMPLETED',
       totalPrizesInCents: 3950,
     });
+  });
+
+  it('releases engagement billing-account rows when an engagement payment is cancelled', async () => {
+    prisma.payment.findMany
+      .mockResolvedValueOnce([
+        {
+          billing_account: '80001012',
+          currency: 'USD',
+          installment_number: 1,
+          payment_id: 'payment-1',
+          payment_status: PaymentStatus.OWED,
+          release_date: new Date('2026-04-28T00:00:00.000Z'),
+          version: 1,
+          winnings: {
+            category: 'ENGAGEMENT_PAYMENT',
+            external_id: 'assignment-1',
+            type: 'PAYMENT',
+          },
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const result = await service.updateWinnings(
+      {
+        paymentId: 'payment-1',
+        paymentStatus: PaymentStatus.CANCELLED,
+        winningsId: 'winning-1',
+      } as any,
+      'admin-1',
+      ['Payment Admin'],
+    );
+
+    expect(result.data).toBe('Successfully updated winnings');
+    expect(prisma.payment.findMany).toHaveBeenNthCalledWith(2, {
+      select: {
+        challenge_fee: true,
+        total_amount: true,
+      },
+      where: {
+        billing_account: '80001012',
+        currency: 'USD',
+        payment_status: { not: PaymentStatus.CANCELLED },
+        winnings: {
+          category: 'ENGAGEMENT_PAYMENT',
+          external_id: 'assignment-1',
+          type: 'PAYMENT',
+        },
+      },
+      orderBy: [{ created_at: 'asc' }, { payment_id: 'asc' }],
+    });
+    expect(baService.syncEngagementConsumeAmounts).toHaveBeenCalledWith({
+      amounts: [],
+      billingAccountId: 80001012,
+      externalId: 'assignment-1',
+    });
+    expect(baService.lockConsumeAmount).not.toHaveBeenCalled();
   });
 
   it('returns task details for task payment with projectId and approver', async () => {

--- a/src/api/admin/admin.service.ts
+++ b/src/api/admin/admin.service.ts
@@ -36,10 +36,16 @@ import {
 import { WinningPaymentDetailsDto } from './dto/payment-details.dto';
 
 const PAYMENT_DECIMAL_PLACES = 2;
+const BUDGET_LEDGER_DECIMAL_PLACES = 4;
 
 interface ChallengeBudgetSyncTarget {
   billingAccountId: number;
   challengeId: string;
+}
+
+interface EngagementBudgetSyncTarget {
+  assignmentId: string;
+  billingAccountId: number;
 }
 
 /**
@@ -395,6 +401,55 @@ export class AdminService {
   }
 
   /**
+   * Finds engagement billing-account rows that need to be reconciled after a
+   * wallet-admin payment status change.
+   *
+   * @param payments payment rows selected by the update request.
+   * @returns unique engagement assignment and billing-account pairs touched by
+   * USD engagement payments.
+   * @throws This helper does not throw.
+   */
+  private getEngagementBudgetSyncTargets(
+    payments: Awaited<ReturnType<AdminService['getPaymentsByWinningsId']>>,
+  ): EngagementBudgetSyncTarget[] {
+    const targets = new Map<string, EngagementBudgetSyncTarget>();
+
+    payments.forEach((payment) => {
+      const assignmentId =
+        typeof payment.winnings.external_id === 'string'
+          ? payment.winnings.external_id.trim()
+          : '';
+
+      if (
+        !assignmentId ||
+        payment.winnings.type !== winnings_type.PAYMENT ||
+        payment.winnings.category !== winnings_category.ENGAGEMENT_PAYMENT ||
+        (payment.currency ?? '') !== 'USD'
+      ) {
+        return;
+      }
+
+      const billingAccountId = this.normalizeBillingAccountId(
+        payment.billing_account,
+      );
+
+      if (!billingAccountId) {
+        this.logger.warn(
+          `Skipping engagement budget sync for payment ${payment.payment_id}; invalid billing account ${String(payment.billing_account)}`,
+        );
+        return;
+      }
+
+      targets.set(`${assignmentId}:${billingAccountId}`, {
+        assignmentId,
+        billingAccountId,
+      });
+    });
+
+    return [...targets.values()];
+  }
+
+  /**
    * Resolves the billing account to synchronize for a challenge.
    *
    * @param challenge challenge-api-v6 payload.
@@ -462,6 +517,25 @@ export class AdminService {
       amount
         .toDecimalPlaces(PAYMENT_DECIMAL_PLACES, Prisma.Decimal.ROUND_HALF_UP)
         .toFixed(PAYMENT_DECIMAL_PLACES),
+    );
+  }
+
+  /**
+   * Quantizes a billing-account ledger amount to the same four-decimal scale
+   * used by billing-accounts-api-v6.
+   *
+   * @param amount decimal amount to normalize.
+   * @returns JavaScript number rounded to four decimal places.
+   * @throws This helper does not throw.
+   */
+  private toBillingLedgerAmount(amount: Prisma.Decimal): number {
+    return Number(
+      amount
+        .toDecimalPlaces(
+          BUDGET_LEDGER_DECIMAL_PLACES,
+          Prisma.Decimal.ROUND_HALF_UP,
+        )
+        .toFixed(BUDGET_LEDGER_DECIMAL_PLACES),
     );
   }
 
@@ -542,6 +616,74 @@ export class AdminService {
           markup,
           status: challenge.status,
           totalPrizesInCents: totalUsdAmount * 100,
+        });
+      }),
+    );
+  }
+
+  /**
+   * Reads active engagement payment ledger amounts for one assignment.
+   *
+   * @param assignmentId engagement assignment external id stored on winnings.
+   * @param billingAccountId billing account stored on payment rows.
+   * @returns ledger-scale consumed amounts for non-cancelled finance payments,
+   * in the same order used when engagement consumed rows were created.
+   * @throws Prisma errors when the payment query fails.
+   */
+  private async getActiveEngagementConsumeAmounts(
+    assignmentId: string,
+    billingAccountId: number,
+  ): Promise<number[]> {
+    const payments = await this.prisma.payment.findMany({
+      select: {
+        challenge_fee: true,
+        total_amount: true,
+      },
+      where: {
+        billing_account: String(billingAccountId),
+        currency: PrizeType.USD,
+        payment_status: { not: payment_status.CANCELLED },
+        winnings: {
+          category: winnings_category.ENGAGEMENT_PAYMENT,
+          external_id: assignmentId,
+          type: winnings_type.PAYMENT,
+        },
+      },
+      orderBy: [{ created_at: 'asc' }, { payment_id: 'asc' }],
+    });
+
+    return payments.map((paymentRow) =>
+      this.toBillingLedgerAmount(
+        new Prisma.Decimal(paymentRow.total_amount ?? 0).plus(
+          new Prisma.Decimal(paymentRow.challenge_fee ?? 0),
+        ),
+      ),
+    );
+  }
+
+  /**
+   * Reconciles engagement billing-account consumed rows after a wallet-admin
+   * cancellation changes the active payment set.
+   *
+   * @param targets unique engagement assignment and billing-account pairs to
+   * synchronize.
+   * @returns promise resolved after every target has been reconciled in BA.
+   * @throws Error when BA synchronization fails.
+   */
+  private async syncEngagementBudgetTargets(
+    targets: EngagementBudgetSyncTarget[],
+  ): Promise<void> {
+    await Promise.all(
+      targets.map(async (target) => {
+        const amounts = await this.getActiveEngagementConsumeAmounts(
+          target.assignmentId,
+          target.billingAccountId,
+        );
+
+        await this.baService.syncEngagementConsumeAmounts({
+          amounts,
+          billingAccountId: target.billingAccountId,
+          externalId: target.assignmentId,
         });
       }),
     );
@@ -641,6 +783,10 @@ export class AdminService {
       const challengeBudgetSyncTargets =
         body.paymentStatus === PaymentStatus.CANCELLED
           ? this.getChallengeBudgetSyncTargets(payments)
+          : [];
+      const engagementBudgetSyncTargets =
+        body.paymentStatus === PaymentStatus.CANCELLED
+          ? this.getEngagementBudgetSyncTargets(payments)
           : [];
 
       // iterate payments and build transaction list
@@ -926,6 +1072,10 @@ export class AdminService {
 
       if (challengeBudgetSyncTargets.length > 0) {
         await this.syncChallengeBudgetTargets(challengeBudgetSyncTargets);
+      }
+
+      if (engagementBudgetSyncTargets.length > 0) {
+        await this.syncEngagementBudgetTargets(engagementBudgetSyncTargets);
       }
 
       if (needsReconciliation) {

--- a/src/shared/topcoder/billing-accounts.service.spec.ts
+++ b/src/shared/topcoder/billing-accounts.service.spec.ts
@@ -17,6 +17,18 @@ jest.mock('src/shared/global', () => ({
   },
 }));
 
+const mockBaTx = {
+  $executeRawUnsafe: jest.fn(),
+  $queryRawUnsafe: jest.fn(),
+};
+const mockBaClient = {
+  $transaction: jest.fn(),
+};
+
+jest.mock('src/shared/global/ba-prisma.client', () => ({
+  getBaClient: jest.fn(() => mockBaClient),
+}));
+
 import { ChallengeStatuses } from 'src/dto/challenge.dto';
 import { BillingAccountsService } from './billing-accounts.service';
 
@@ -24,6 +36,15 @@ describe('BillingAccountsService', () => {
   let service: BillingAccountsService;
 
   beforeEach(() => {
+    jest.clearAllMocks();
+    mockBaTx.$executeRawUnsafe.mockResolvedValue(undefined);
+    mockBaTx.$queryRawUnsafe
+      .mockResolvedValueOnce([{ exists: true }])
+      .mockResolvedValueOnce([]);
+    mockBaClient.$transaction.mockImplementation(
+      (callback: (tx: typeof mockBaTx) => unknown) => callback(mockBaTx),
+    );
+
     service = new BillingAccountsService({} as any);
   });
 
@@ -94,5 +115,82 @@ describe('BillingAccountsService', () => {
       challengeId: 'challenge-id',
     });
     expect(consumeAmountSpy).not.toHaveBeenCalled();
+  });
+
+  it('deletes stale engagement consumed rows when no active amounts remain', async () => {
+    mockBaTx.$queryRawUnsafe
+      .mockReset()
+      .mockResolvedValueOnce([{ exists: true }])
+      .mockResolvedValueOnce([{ id: 'consumed-row-1' }]);
+
+    await service.syncEngagementConsumeAmounts({
+      amounts: [],
+      billingAccountId: 80001012,
+      externalId: 'assignment-1',
+    });
+
+    expect(mockBaTx.$queryRawUnsafe).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('"externalId" = $2'),
+      80001012,
+      'assignment-1',
+    );
+    expect(mockBaTx.$executeRawUnsafe).toHaveBeenCalledWith(
+      expect.stringContaining('DELETE FROM "ConsumedAmount"'),
+      'consumed-row-1',
+    );
+  });
+
+  it('syncs engagement consumed rows to the active ledger amounts', async () => {
+    mockBaTx.$queryRawUnsafe
+      .mockReset()
+      .mockResolvedValueOnce([{ exists: true }])
+      .mockResolvedValueOnce([{ id: 'consumed-row-1' }, { id: 'stale-row-1' }]);
+
+    await service.syncEngagementConsumeAmounts({
+      amounts: [24.2, 12],
+      billingAccountId: 80001012,
+      externalId: 'assignment-1',
+    });
+
+    expect(mockBaTx.$executeRawUnsafe).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE "ConsumedAmount"'),
+      24.2,
+      'consumed-row-1',
+    );
+    expect(mockBaTx.$executeRawUnsafe).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE "ConsumedAmount"'),
+      12,
+      'stale-row-1',
+    );
+    expect(mockBaTx.$executeRawUnsafe).not.toHaveBeenCalledWith(
+      expect.stringContaining('DELETE FROM "ConsumedAmount"'),
+      expect.any(String),
+    );
+  });
+
+  it('syncs legacy consumed rows with the aggregate active amount', async () => {
+    mockBaTx.$queryRawUnsafe
+      .mockReset()
+      .mockResolvedValueOnce([{ exists: false }])
+      .mockResolvedValueOnce([{ id: 'legacy-row-1' }]);
+
+    await service.syncEngagementConsumeAmounts({
+      amounts: [24.2, 12],
+      billingAccountId: 80001012,
+      externalId: 'assignment-1',
+    });
+
+    expect(mockBaTx.$queryRawUnsafe).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('"challengeId" = $2'),
+      80001012,
+      'assignment-1',
+    );
+    expect(mockBaTx.$executeRawUnsafe).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE "ConsumedAmount"'),
+      36.2,
+      'legacy-row-1',
+    );
   });
 });

--- a/src/shared/topcoder/billing-accounts.service.ts
+++ b/src/shared/topcoder/billing-accounts.service.ts
@@ -3,6 +3,7 @@ import { isNumber, includes } from 'lodash';
 import { ENV_CONFIG } from 'src/config';
 import { ChallengeStatuses } from 'src/dto/challenge.dto';
 import { Logger } from 'src/shared/global';
+import { getBaClient } from 'src/shared/global/ba-prisma.client';
 import {
   TopcoderM2MHttpError,
   TopcoderM2MService,
@@ -46,6 +47,21 @@ interface ConsumeAmountsItemDTO extends ConsumeAmountDTO {
 
 interface ConsumeAmountsDTO {
   consumes: ConsumeAmountsItemDTO[];
+}
+
+interface SyncEngagementConsumeAmountsDTO {
+  amounts: number[];
+  billingAccountId: number;
+  externalId: string;
+}
+
+interface BillingAccountLedgerRow {
+  id: string;
+}
+
+interface BillingAccountLedgerTransaction {
+  $executeRawUnsafe(query: string, ...values: unknown[]): Promise<number>;
+  $queryRawUnsafe<T = unknown>(query: string, ...values: unknown[]): Promise<T>;
 }
 
 interface BillingAccountDetailsResponse {
@@ -346,6 +362,205 @@ export class BillingAccountsService {
       this.logger.error(exception.message, err);
       throw exception;
     }
+  }
+
+  /**
+   * Detects whether the billing-account ledger uses typed external references.
+   *
+   * @param tx active billing-account Prisma transaction.
+   * @returns true when consumed rows expose `externalId` and `externalType`,
+   * false for the legacy `challengeId` column shape.
+   * @throws Prisma errors when the metadata query fails.
+   */
+  private async hasTypedConsumedAmountReferences(
+    tx: BillingAccountLedgerTransaction,
+  ): Promise<boolean> {
+    const rows = await tx.$queryRawUnsafe<{ exists: boolean }[]>(
+      `SELECT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'ConsumedAmount'
+          AND table_schema = ANY (current_schemas(false))
+          AND column_name = 'externalId'
+      ) AS "exists"`,
+    );
+
+    return Boolean(rows[0]?.exists);
+  }
+
+  /**
+   * Reads consumed ledger rows for one engagement assignment.
+   *
+   * @param tx active billing-account Prisma transaction.
+   * @param billingAccountId target billing account id.
+   * @param externalId engagement assignment id.
+   * @param hasTypedReferences whether the ledger uses typed external reference
+   * columns.
+   * @returns matching consumed row ids ordered by ledger creation order.
+   * @throws Prisma errors when the row query fails.
+   */
+  private async getEngagementConsumedRows(
+    tx: BillingAccountLedgerTransaction,
+    billingAccountId: number,
+    externalId: string,
+    hasTypedReferences: boolean,
+  ): Promise<BillingAccountLedgerRow[]> {
+    if (hasTypedReferences) {
+      return tx.$queryRawUnsafe<BillingAccountLedgerRow[]>(
+        `SELECT id
+         FROM "ConsumedAmount"
+         WHERE "billingAccountId" = $1
+           AND "externalId" = $2
+           AND "externalType"::text = 'ENGAGEMENT'
+         ORDER BY "createdAt" ASC, id ASC`,
+        billingAccountId,
+        externalId,
+      );
+    }
+
+    return tx.$queryRawUnsafe<BillingAccountLedgerRow[]>(
+      `SELECT id
+       FROM "ConsumedAmount"
+       WHERE "billingAccountId" = $1
+         AND "challengeId" = $2
+       ORDER BY "createdAt" ASC, id ASC`,
+      billingAccountId,
+      externalId,
+    );
+  }
+
+  /**
+   * Rewrites one consumed ledger row amount.
+   *
+   * @param tx active billing-account Prisma transaction.
+   * @param rowId consumed row id.
+   * @param amount ledger-scale amount to persist.
+   * @returns promise resolved after the row is updated.
+   * @throws Prisma errors when the update fails.
+   */
+  private async updateEngagementConsumedRow(
+    tx: BillingAccountLedgerTransaction,
+    rowId: string,
+    amount: number,
+  ): Promise<void> {
+    await tx.$executeRawUnsafe(
+      `UPDATE "ConsumedAmount"
+       SET amount = $1,
+           "updatedAt" = CURRENT_TIMESTAMP
+       WHERE id = $2`,
+      amount,
+      rowId,
+    );
+  }
+
+  /**
+   * Deletes consumed ledger rows that no longer have active finance payments.
+   *
+   * @param tx active billing-account Prisma transaction.
+   * @param rows consumed rows to remove.
+   * @returns promise resolved after every row is deleted.
+   * @throws Prisma errors when a delete fails.
+   */
+  private async deleteEngagementConsumedRows(
+    tx: BillingAccountLedgerTransaction,
+    rows: BillingAccountLedgerRow[],
+  ): Promise<void> {
+    for (const row of rows) {
+      await tx.$executeRawUnsafe(
+        `DELETE FROM "ConsumedAmount"
+         WHERE id = $1`,
+        row.id,
+      );
+    }
+  }
+
+  /**
+   * Reconciles consumed BA ledger rows for one engagement assignment.
+   *
+   * Engagement consumes are written as one billing-account consumed row per
+   * finance payment. Wallet-admin cancellation must therefore rewrite the rows
+   * for the assignment to match the still-active finance payments and delete
+   * stale rows for payments that are now cancelled.
+   *
+   * @param dto engagement assignment external id, billing account id, and
+   * active ledger amounts to keep.
+   * @returns promise resolved after the billing-account ledger rows are synced.
+   * @throws BadRequestException when the sync target or amounts are invalid.
+   * @throws Prisma errors when the billing-account database update fails.
+   */
+  async syncEngagementConsumeAmounts(
+    dto: SyncEngagementConsumeAmountsDTO,
+  ): Promise<void> {
+    const externalId =
+      typeof dto.externalId === 'string' ? dto.externalId.trim() : '';
+
+    if (
+      !Number.isSafeInteger(dto.billingAccountId) ||
+      dto.billingAccountId <= 0
+    ) {
+      throw new BadRequestException(
+        'billingAccountId must be a positive integer',
+      );
+    }
+
+    if (!externalId) {
+      throw new BadRequestException('externalId is required');
+    }
+
+    if (includes(TGBillingAccounts, dto.billingAccountId)) {
+      this.logger.info(
+        'Ignore BA validation for Topgear account:',
+        dto.billingAccountId,
+      );
+      return;
+    }
+
+    const amounts = dto.amounts.filter((amount) => {
+      if (!Number.isFinite(amount) || amount < 0) {
+        throw new BadRequestException(
+          'engagement consume amounts must be non-negative finite numbers',
+        );
+      }
+
+      return amount > 0;
+    });
+
+    const baClient = getBaClient();
+
+    await baClient.$transaction(async (tx) => {
+      const hasTypedReferences =
+        await this.hasTypedConsumedAmountReferences(tx);
+      const existingRows = await this.getEngagementConsumedRows(
+        tx,
+        dto.billingAccountId,
+        externalId,
+        hasTypedReferences,
+      );
+      const syncAmounts = hasTypedReferences
+        ? amounts
+        : [
+            Number(amounts.reduce((sum, amount) => sum + amount, 0).toFixed(4)),
+          ].filter((amount) => amount > 0);
+
+      for (const [index, amount] of syncAmounts.entries()) {
+        const existingRow = existingRows[index];
+
+        if (existingRow) {
+          await this.updateEngagementConsumedRow(tx, existingRow.id, amount);
+          continue;
+        }
+
+        this.logger.warn(
+          `Missing engagement consumed row for assignment ${externalId} on billing account ${dto.billingAccountId}`,
+        );
+      }
+
+      const staleRows = existingRows.slice(syncAmounts.length);
+
+      if (staleRows.length > 0) {
+        await this.deleteEngagementConsumedRows(tx, staleRows);
+      }
+    });
   }
 
   async lockConsumeAmount(


### PR DESCRIPTION
What was broken
Cancelling an engagement payment from wallet-admin updated the finance payment status, but the engagement consumed row in the billing-account ledger stayed in place. The BA details modal still showed the cancelled engagement amount as consumed.

Root cause (if identifiable)
The previous PM-4958 fix only recalculated challenge payment budget rows. Engagement payments were explicitly excluded from that path, and their BA consumed rows are maintained separately from challenge budget rows.

What was changed
Added wallet-admin cancellation handling for engagement payments. After the finance status transaction succeeds, the admin service now recalculates the active non-cancelled engagement ledger amounts and asks the billing-account service to sync the matching consumed rows, deleting stale rows when cancelled payments should no longer reserve budget. The sync supports both the legacy challengeId BA ledger shape and the newer typed externalId/externalType shape.

Any added/updated tests
Added AdminService coverage for engagement payment cancellation triggering BA sync. Added BillingAccountsService coverage for deleting stale engagement consumed rows, syncing active typed rows, and syncing legacy aggregate rows.

Validation
source "$HOME/.nvm/nvm.sh" && nvm use && pnpm lint
source "$HOME/.nvm/nvm.sh" && nvm use && pnpm test -- --runInBand
source "$HOME/.nvm/nvm.sh" && nvm use && pnpm build
