### PR TITLE
Keep payment status

### DIFF
--- a/src/api/challenges/challenges.service.ts
+++ b/src/api/challenges/challenges.service.ts
@@ -513,12 +513,6 @@ export class ChallengesService {
     );
 
     return payments.map((payment) => {
-      const paymentStatus =
-        payment.status ??
-        (challenge.task?.isTask && payment.currency === PrizeType.USD
-          ? PaymentStatus.ON_HOLD_ADMIN
-          : undefined);
-
       return {
         winnerId: payment.userId.toString(),
         type:
@@ -530,7 +524,7 @@ export class ChallengesService {
         title: challenge.name,
         description: payment.description || challenge.name,
         externalId: challenge.id,
-        ...(paymentStatus ? { status: paymentStatus } : {}),
+        ...(payment.status ? { status: payment.status } : {}),
         details: [
           {
             totalAmount: payment.amount,


### PR DESCRIPTION
This pull request simplifies the logic for determining the `status` field in the payment mapping within the `ChallengesService`. Instead of using a fallback or conditional logic, the code now directly uses the `status` from the `payment` object if it exists.

Payment status logic simplification:

* Removed the conditional assignment of `paymentStatus` that checked for `challenge.task?.isTask` and `payment.currency` to determine if the status should be set to `ON_HOLD_ADMIN`; now, only `payment.status` is used when constructing the result.
* Updated the object spread to include the `status` field only if `payment.status` is present, removing the use of the previously computed `paymentStatus`.