### PR TITLE
PM-4972: Sync BA summary after wallet amount edits

### DIFF
--- a/src/api/admin/admin.service.spec.ts
+++ b/src/api/admin/admin.service.spec.ts
@@ -515,6 +515,158 @@ describe('AdminService', () => {
     expect(baService.lockConsumeAmount).not.toHaveBeenCalled();
   });
 
+  it('recalculates the challenge billing-account line item when a challenge payment amount is adjusted', async () => {
+    prisma.payment.findMany
+      .mockResolvedValueOnce([
+        {
+          billing_account: '80001012',
+          currency: 'USD',
+          installment_number: 1,
+          payment_id: 'payment-1',
+          payment_status: PaymentStatus.OWED,
+          release_date: new Date('2026-04-27T00:00:00.000Z'),
+          total_amount: '100.00',
+          version: 1,
+          winnings: {
+            category: 'CONTEST_PAYMENT',
+            description: 'Challenge payment',
+            external_id: 'challenge-1',
+            type: 'PAYMENT',
+          },
+        },
+      ])
+      .mockResolvedValueOnce([
+        { total_amount: '150.00' },
+        { total_amount: '25.00' },
+      ]);
+    topcoderChallengesService.getChallengeById.mockResolvedValue({
+      billing: {
+        billingAccountId: '80001012',
+        markup: 0.1,
+      },
+      id: 'challenge-1',
+      status: 'COMPLETED',
+    });
+
+    const result = await service.updateWinnings(
+      {
+        paymentAmount: 150,
+        paymentId: 'payment-1',
+        winningsId: 'winning-1',
+      } as any,
+      'admin-1',
+      ['Payment Admin'],
+    );
+
+    expect(result.data).toBe('Successfully updated winnings');
+    expect(prisma.payment.update).toHaveBeenCalledWith({
+      where: {
+        payment_id: 'payment-1',
+        winnings_id: 'winning-1',
+        version: 1,
+        payment_status: {
+          in: [
+            PaymentStatus.CREDITED,
+            PaymentStatus.OWED,
+            PaymentStatus.ON_HOLD,
+            PaymentStatus.ON_HOLD_ADMIN,
+            PaymentStatus.PAID,
+            PaymentStatus.PROCESSING,
+          ],
+        },
+      },
+      data: {
+        challenge_fee: undefined,
+        gross_amount: 150,
+        net_amount: 150,
+        total_amount: 150,
+        updated_at: expect.any(Date),
+        updated_by: 'admin-1',
+        version: 2,
+      },
+    });
+    expect(baService.lockConsumeAmount).toHaveBeenCalledWith({
+      billingAccountId: 80001012,
+      challengeId: 'challenge-1',
+      markup: 0.1,
+      status: 'COMPLETED',
+      totalPrizesInCents: 17500,
+    });
+  });
+
+  it('updates engagement challenge fee and consumed rows when an engagement payment amount is adjusted', async () => {
+    prisma.payment.findMany
+      .mockResolvedValueOnce([
+        {
+          billing_account: '80001012',
+          challenge_markup: '0.20',
+          currency: 'USD',
+          installment_number: 1,
+          payment_id: 'payment-1',
+          payment_status: PaymentStatus.OWED,
+          release_date: new Date('2026-04-28T00:00:00.000Z'),
+          total_amount: '100.00',
+          version: 1,
+          winnings: {
+            category: 'ENGAGEMENT_PAYMENT',
+            description: 'Engagement payment',
+            external_id: 'assignment-1',
+            type: 'PAYMENT',
+          },
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          challenge_fee: '30.00',
+          total_amount: '150.00',
+        },
+      ]);
+
+    const result = await service.updateWinnings(
+      {
+        paymentAmount: 150,
+        paymentId: 'payment-1',
+        winningsId: 'winning-1',
+      } as any,
+      'admin-1',
+      ['Payment Admin'],
+    );
+
+    expect(result.data).toBe('Successfully updated winnings');
+    expect(prisma.payment.update).toHaveBeenCalledWith({
+      where: {
+        payment_id: 'payment-1',
+        winnings_id: 'winning-1',
+        version: 1,
+        payment_status: {
+          in: [
+            PaymentStatus.CREDITED,
+            PaymentStatus.OWED,
+            PaymentStatus.ON_HOLD,
+            PaymentStatus.ON_HOLD_ADMIN,
+            PaymentStatus.PAID,
+            PaymentStatus.PROCESSING,
+          ],
+        },
+      },
+      data: {
+        challenge_fee: 30,
+        gross_amount: 150,
+        net_amount: 150,
+        total_amount: 150,
+        updated_at: expect.any(Date),
+        updated_by: 'admin-1',
+        version: 2,
+      },
+    });
+    expect(baService.syncEngagementConsumeAmounts).toHaveBeenCalledWith({
+      amounts: [180],
+      billingAccountId: 80001012,
+      externalId: 'assignment-1',
+    });
+    expect(baService.lockConsumeAmount).not.toHaveBeenCalled();
+  });
+
   it('returns task details for task payment with projectId and approver', async () => {
     prisma.winnings.findFirst.mockResolvedValue({
       winning_id: 'winning-task',

--- a/src/api/admin/admin.service.ts
+++ b/src/api/admin/admin.service.ts
@@ -353,7 +353,7 @@ export class AdminService {
 
   /**
    * Finds challenge billing-account rows that need to be recalculated after a
-   * wallet-admin payment status change.
+   * wallet-admin payment status or amount change.
    *
    * @param payments payment rows selected by the update request.
    * @returns unique challenge and billing-account pairs touched by USD
@@ -402,7 +402,7 @@ export class AdminService {
 
   /**
    * Finds engagement billing-account rows that need to be reconciled after a
-   * wallet-admin payment status change.
+   * wallet-admin payment status or amount change.
    *
    * @param payments payment rows selected by the update request.
    * @returns unique engagement assignment and billing-account pairs touched by
@@ -540,6 +540,39 @@ export class AdminService {
   }
 
   /**
+   * Recomputes the persisted engagement billing fee after an admin amount edit.
+   *
+   * Engagement consumed rows store payment total plus `payment.challenge_fee`.
+   * When wallet admin adjusts the payment total, the fee must be recalculated
+   * from the persisted markup before finance resyncs the BA consumed row.
+   *
+   * @param category winning category for the payment being edited.
+   * @param challengeMarkup markup persisted on the payment row.
+   * @param totalAmount new payment total amount.
+   * @returns recalculated fee for engagement payments, or `undefined` when the
+   * payment is not an engagement payment or has no valid persisted markup.
+   * @throws This helper does not throw.
+   */
+  private calculateAdjustedChallengeFee(
+    category: winnings_category | null,
+    challengeMarkup: Prisma.Decimal | number | string | null,
+    totalAmount: number,
+  ): number | undefined {
+    if (category !== winnings_category.ENGAGEMENT_PAYMENT) {
+      return undefined;
+    }
+
+    const markup = Number(challengeMarkup);
+    if (!Number.isFinite(markup) || markup < 0) {
+      return undefined;
+    }
+
+    return this.toPaymentAmount(
+      new Prisma.Decimal(totalAmount).mul(new Prisma.Decimal(markup)),
+    );
+  }
+
+  /**
    * Sums non-cancelled USD payment rows for a challenge and billing account.
    *
    * @param challengeId challenge external id stored on winnings.
@@ -574,8 +607,8 @@ export class AdminService {
   }
 
   /**
-   * Rewrites challenge billing-account budget rows after a wallet-admin status
-   * update changes the active payment total.
+   * Rewrites challenge billing-account budget rows after a wallet-admin update
+   * changes the active payment total.
    *
    * @param targets unique challenge and billing-account pairs to synchronize.
    * @returns promise resolved after every target has been sent to BA.
@@ -663,7 +696,7 @@ export class AdminService {
 
   /**
    * Reconciles engagement billing-account consumed rows after a wallet-admin
-   * cancellation changes the active payment set.
+   * update changes the active payment amounts or active payment set.
    *
    * @param targets unique engagement assignment and billing-account pairs to
    * synchronize.
@@ -780,14 +813,15 @@ export class AdminService {
         tx: Prisma.TransactionClient,
       ) => Promise<unknown>)[] = [];
       const now = new Date().getTime();
-      const challengeBudgetSyncTargets =
-        body.paymentStatus === PaymentStatus.CANCELLED
-          ? this.getChallengeBudgetSyncTargets(payments)
-          : [];
-      const engagementBudgetSyncTargets =
-        body.paymentStatus === PaymentStatus.CANCELLED
-          ? this.getEngagementBudgetSyncTargets(payments)
-          : [];
+      const shouldSyncBudget =
+        body.paymentStatus === PaymentStatus.CANCELLED ||
+        body.paymentAmount !== undefined;
+      const challengeBudgetSyncTargets = shouldSyncBudget
+        ? this.getChallengeBudgetSyncTargets(payments)
+        : [];
+      const engagementBudgetSyncTargets = shouldSyncBudget
+        ? this.getEngagementBudgetSyncTargets(payments)
+        : [];
 
       // iterate payments and build transaction list
       payments.forEach((payment) => {
@@ -999,6 +1033,12 @@ export class AdminService {
         ) {
           // ideally we should be maintaining the original split of the payment amount between installments - but we aren't really using splits anymore
           if (payment.installment_number === 1) {
+            const challengeFee = this.calculateAdjustedChallengeFee(
+              payment.winnings.category,
+              payment.challenge_markup,
+              body.paymentAmount,
+            );
+
             transactions.push((tx) =>
               this.updatePaymentAmount(
                 userId,
@@ -1007,6 +1047,7 @@ export class AdminService {
                 body.paymentAmount,
                 body.paymentAmount,
                 body.paymentAmount,
+                challengeFee,
                 version,
                 tx,
               ),
@@ -1027,6 +1068,12 @@ export class AdminService {
               `update amounts -> ${body.paymentAmount.toFixed(2)} (installment 1)`,
             );
           } else {
+            const challengeFee = this.calculateAdjustedChallengeFee(
+              payment.winnings.category,
+              payment.challenge_markup,
+              body.paymentAmount,
+            );
+
             transactions.push((tx) =>
               this.updatePaymentAmount(
                 userId,
@@ -1035,6 +1082,7 @@ export class AdminService {
                 0,
                 0,
                 body.paymentAmount,
+                challengeFee,
                 version,
                 tx,
               ),
@@ -1436,6 +1484,7 @@ export class AdminService {
     netAmount: number,
     grossAmount: number,
     totalAmount: number,
+    challengeFee: number | undefined,
     currentVersion: number,
     tx?: Prisma.TransactionClient,
   ) {
@@ -1459,6 +1508,7 @@ export class AdminService {
         net_amount: netAmount,
         gross_amount: grossAmount,
         total_amount: totalAmount,
+        challenge_fee: challengeFee,
         updated_at: new Date(),
         updated_by: userId,
         version: currentVersion + 1,

--- a/src/api/challenges/challenges.service.ts
+++ b/src/api/challenges/challenges.service.ts
@@ -557,7 +557,7 @@ export class ChallengesService {
         title: challenge.name,
         description: payment.description || challenge.name,
         externalId: challenge.id,
-        ...(payment.status ? { status: payment.status } : {}),
+        ...(paymentStatus ? { status: paymentStatus } : {}),
         details: [
           {
             totalAmount: payment.amount,


### PR DESCRIPTION
What was broken
Wallet-admin payment amount adjustments did not trigger billing-account budget reconciliation, so BA summary rows stayed at the prior consumed amount.

Root cause
Finance only recalculated BA challenge and engagement ledger rows when wallet admin cancelled a payment. Amount-only edits updated finance payment rows but skipped the BA sync path. Engagement edits also left the persisted challenge fee based on the old amount.

What was changed
Reuse BA sync target discovery for wallet-admin amount edits.
Recalculate engagement challenge_fee from the persisted markup during amount updates before syncing consumed rows.
Preserve computed task payment status in challenge-generated payments so lint and existing status behavior stay aligned.

Any added/updated tests
Added admin service coverage for challenge and engagement amount adjustments syncing BA rows.
Validated with targeted admin service tests, full Jest suite, lint, and build.
