### PR TITLE
PM-4669 - support for payment cycles engagement payments

### DIFF
--- a/src/api/admin/admin.service.ts
+++ b/src/api/admin/admin.service.ts
@@ -33,7 +33,10 @@ import {
   TopcoderChallengeInfo,
   TopcoderChallengesService,
 } from 'src/shared/topcoder/challenges.service';
-import { WinningPaymentDetailsDto } from './dto/payment-details.dto';
+import {
+  PaymentCycle,
+  WinningPaymentDetailsDto,
+} from './dto/payment-details.dto';
 
 const PAYMENT_DECIMAL_PLACES = 2;
 const BUDGET_LEDGER_DECIMAL_PLACES = 4;
@@ -261,6 +264,13 @@ export class AdminService {
       assignment.standardHoursPerWeek !== null
         ? Number(assignment.standardHoursPerWeek)
         : undefined;
+    const standardHoursPerDay =
+      assignment?.standardHoursPerDay !== undefined &&
+      assignment.standardHoursPerDay !== null
+        ? Number(assignment.standardHoursPerDay)
+        : Number.isFinite(standardHoursPerWeek)
+          ? Number(((standardHoursPerWeek ?? 0) / 5).toFixed(2))
+          : undefined;
     const projectId = engagement.projectId ?? engagement.project?.id;
     const projectName =
       (engagement.projectName ?? engagement.project?.name)?.trim() ?? undefined;
@@ -288,6 +298,11 @@ export class AdminService {
         ? durationMonths
         : undefined,
       ratePerHour: assignment?.ratePerHour?.trim() ?? undefined,
+      paymentCycle: (assignment?.paymentCycle?.trim() ||
+        'WEEKLY') as PaymentCycle,
+      standardHoursPerDay: Number.isFinite(standardHoursPerDay)
+        ? standardHoursPerDay
+        : undefined,
       standardHoursPerWeek: Number.isFinite(standardHoursPerWeek)
         ? standardHoursPerWeek
         : undefined,
@@ -1301,6 +1316,14 @@ export class AdminService {
             : undefined,
           durationMonths: assignmentContext.durationMonths ?? undefined,
           ratePerHour: assignmentContext.ratePerHour ?? undefined,
+          paymentCycle: (assignmentContext.paymentCycle ??
+            'WEEKLY') as PaymentCycle,
+          standardHoursPerDay:
+            assignmentContext.standardHoursPerDay ??
+            (assignmentContext.standardHoursPerWeek !== undefined &&
+            assignmentContext.standardHoursPerWeek !== null
+              ? Number((assignmentContext.standardHoursPerWeek / 5).toFixed(2))
+              : undefined),
           standardHoursPerWeek:
             assignmentContext.standardHoursPerWeek ?? undefined,
           otherRemarks: assignmentContext.otherRemarks ?? undefined,

--- a/src/api/admin/dto/payment-details.dto.ts
+++ b/src/api/admin/dto/payment-details.dto.ts
@@ -1,5 +1,7 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
+export type PaymentCycle = 'WEEKLY' | 'FORTNIGHTLY' | 'MONTHLY';
+
 export class PaymentEngagementDetailsDto {
   @ApiPropertyOptional({
     description: 'The assignment ID associated with the payment',
@@ -48,6 +50,19 @@ export class PaymentEngagementDetailsDto {
     example: '75.50',
   })
   ratePerHour?: string;
+
+  @ApiPropertyOptional({
+    description: 'Assignment payment cycle',
+    enum: ['WEEKLY', 'FORTNIGHTLY', 'MONTHLY'],
+    example: 'WEEKLY',
+  })
+  paymentCycle?: PaymentCycle;
+
+  @ApiPropertyOptional({
+    description: 'Assignment standard hours per day',
+    example: 8,
+  })
+  standardHoursPerDay?: number;
 
   @ApiPropertyOptional({
     description: 'Assignment standard hours per week',

--- a/src/shared/topcoder/engagements.service.ts
+++ b/src/shared/topcoder/engagements.service.ts
@@ -17,9 +17,11 @@ export interface TopcoderAssignmentContext {
   memberHandle: string;
   memberId: string;
   otherRemarks?: string | null;
+  paymentCycle?: string | null;
   projectId: string;
   projectName?: string;
   ratePerHour?: string | null;
+  standardHoursPerDay?: number | null;
   standardHoursPerWeek?: number | null;
   startDate?: string | null;
   status: string;
@@ -34,7 +36,9 @@ export interface TopcoderEngagementAssignment {
   memberHandle?: string | null;
   memberId?: string | number | null;
   otherRemarks?: string | null;
+  paymentCycle?: string | null;
   ratePerHour?: string | null;
+  standardHoursPerDay?: number | string | null;
   startDate?: string | null;
   standardHoursPerWeek?: number | string | null;
 }


### PR DESCRIPTION
This pull request enhances the handling of payment details for assignments by introducing support for a `paymentCycle` field and a `standardHoursPerDay` field throughout the admin service and related DTOs. These changes ensure that assignment payment cycles and daily standard hours are consistently managed and exposed via the API, improving data accuracy and flexibility.

**Payment Details Enhancements:**

* Added a new `PaymentCycle` type (`'WEEKLY' | 'FORTNIGHTLY' | 'MONTHLY'`) and integrated it into the `PaymentEngagementDetailsDto` and related logic, allowing assignments to specify their payment cycle.
* Introduced a `standardHoursPerDay` field to `PaymentEngagementDetailsDto` and related interfaces, with logic to derive its value from `standardHoursPerWeek` when not explicitly provided.
**Service and Interface Updates:**

* Updated `AdminService` to handle the new `paymentCycle` and `standardHoursPerDay` fields when transforming assignment and engagement data, ensuring default values and correct type casting.
* Extended `TopcoderAssignmentContext` and `TopcoderEngagementAssignment` interfaces to include the new fields, supporting end-to-end data flow. 