### PR TITLE
PM-5049 - make release window configurable for engagement payments

### DIFF
--- a/src/api/winnings/winnings.service.spec.ts
+++ b/src/api/winnings/winnings.service.spec.ts
@@ -318,7 +318,10 @@ describe('WinningsService', () => {
     const persistedPayment =
       tx.winnings.create.mock.calls[0][0].data.payment.create[0];
 
-    expect(persistedPayment.release_date).toBeNull();
+    expect(persistedPayment.release_date).toBeUndefined();
+    expect(
+      Object.prototype.hasOwnProperty.call(persistedPayment, 'release_date'),
+    ).toBe(false);
   });
 
   it('rejects engagement payment details that do not match the assignment billing account', async () => {

--- a/src/api/winnings/winnings.service.spec.ts
+++ b/src/api/winnings/winnings.service.spec.ts
@@ -1,5 +1,6 @@
 jest.mock('src/config', () => ({
   ENV_CONFIG: {
+    ENGAGEMENT_PAYMENT_RELEASE_WINDOW_DAYS: 5,
     SENDGRID_TEMPLATE_ID_PAYMENT_SETUP_NOTIFICATION: 'template-id',
     TGBillingAccounts: [80000062, 80002800],
     TOPCODER_WALLET_URL: 'https://wallet.topcoder.com',
@@ -254,6 +255,70 @@ describe('WinningsService', () => {
         },
       ],
     });
+  });
+
+  it('applies a short release window to engagement payments', async () => {
+    const beforeCreate = Date.now();
+
+    await service.createWinningWithPayments(
+      {
+        winnerId: 'user-1',
+        type: WinningsType.PAYMENT,
+        origin: 'Topcoder',
+        category: WinningsCategory.ENGAGEMENT_PAYMENT,
+        title: 'Engagement work',
+        description: 'Engagement payment',
+        externalId: 'assignment-1',
+        details: [
+          {
+            totalAmount: 100,
+            grossAmount: 100,
+            installmentNumber: 1,
+            currency: PrizeType.USD,
+            billingAccount: '123456',
+          },
+        ],
+      } as any,
+      'creator-1',
+    );
+
+    const persistedPayment =
+      tx.winnings.create.mock.calls[0][0].data.payment.create[0];
+
+    const releaseDate = new Date(persistedPayment.release_date).getTime();
+    const daysUntilRelease = (releaseDate - beforeCreate) / (24 * 60 * 60 * 1000);
+
+    expect(daysUntilRelease).toBeGreaterThanOrEqual(4.99);
+    expect(daysUntilRelease).toBeLessThanOrEqual(5.01);
+  });
+
+  it('keeps the default release window for non-engagement payments', async () => {
+    await service.createWinningWithPayments(
+      {
+        winnerId: 'user-1',
+        type: WinningsType.PAYMENT,
+        origin: 'Topcoder',
+        category: WinningsCategory.CONTEST_PAYMENT,
+        title: 'Contest payout',
+        description: 'Contest payment',
+        externalId: 'challenge-1',
+        details: [
+          {
+            totalAmount: 100,
+            grossAmount: 100,
+            installmentNumber: 1,
+            currency: PrizeType.USD,
+            billingAccount: '80001012',
+          },
+        ],
+      } as any,
+      'creator-1',
+    );
+
+    const persistedPayment =
+      tx.winnings.create.mock.calls[0][0].data.payment.create[0];
+
+    expect(persistedPayment.release_date).toBeNull();
   });
 
   it('rejects engagement payment details that do not match the assignment billing account', async () => {

--- a/src/api/winnings/winnings.service.ts
+++ b/src/api/winnings/winnings.service.ts
@@ -1289,10 +1289,10 @@ export class WinningsService {
           tx,
         );
 
+      const engagementReleaseDate = isEngagementPayment
+        ? this.buildEngagementReleaseDate()
+        : undefined;
       for (const [detailIndex, detail] of (body.details || []).entries()) {
-        const engagementReleaseDate = isEngagementPayment
-          ? this.buildEngagementReleaseDate()
-          : undefined;
         const challengeFee = engagementConsumePlan
           ? this.calculateEngagementChallengeFee(
               Number(detail.totalAmount),
@@ -1315,7 +1315,9 @@ export class WinningsService {
             ? Prisma.Decimal(engagementConsumePlan.challengeMarkup)
             : null,
           challenge_fee: Prisma.Decimal(challengeFee),
-          release_date: engagementReleaseDate ?? null,
+          ...(engagementReleaseDate !== undefined
+            ? { release_date: engagementReleaseDate }
+            : {}),
         };
 
         paymentModel.net_amount = Prisma.Decimal(detail.grossAmount);

--- a/src/api/winnings/winnings.service.ts
+++ b/src/api/winnings/winnings.service.ts
@@ -69,12 +69,17 @@ interface ChallengeBillingAccountSyncPlan {
   status: string;
 }
 
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
 /**
  * The winning service.
  */
 @Injectable()
 export class WinningsService {
   private readonly logger = new Logger(WinningsService.name);
+
+  private readonly engagementPaymentReleaseWindowDays =
+    ENV_CONFIG.ENGAGEMENT_PAYMENT_RELEASE_WINDOW_DAYS;
 
   /**
    * Constructs the admin winning service with the given dependencies.
@@ -274,6 +279,18 @@ export class WinningsService {
         : undefined;
 
     return attributes?.[CHALLENGE_BUDGET_SYNC_SKIP_ATTRIBUTE] === true;
+  }
+
+  /**
+   * Calculates the default release date for engagement payments.
+   *
+   * @returns A Date offset from now by the configured engagement release
+   * window.
+   */
+  private buildEngagementReleaseDate(): Date {
+    return new Date(
+      Date.now() + this.engagementPaymentReleaseWindowDays * DAY_IN_MS,
+    );
   }
 
   /**
@@ -1242,6 +1259,7 @@ export class WinningsService {
             | 'billing_account'
             | 'challenge_markup'
             | 'challenge_fee'
+            | 'release_date'
           >[],
         },
       };
@@ -1272,6 +1290,9 @@ export class WinningsService {
         );
 
       for (const [detailIndex, detail] of (body.details || []).entries()) {
+        const engagementReleaseDate = isEngagementPayment
+          ? this.buildEngagementReleaseDate()
+          : undefined;
         const challengeFee = engagementConsumePlan
           ? this.calculateEngagementChallengeFee(
               Number(detail.totalAmount),
@@ -1294,6 +1315,7 @@ export class WinningsService {
             ? Prisma.Decimal(engagementConsumePlan.challengeMarkup)
             : null,
           challenge_fee: Prisma.Decimal(challengeFee),
+          release_date: engagementReleaseDate ?? null,
         };
 
         paymentModel.net_amount = Prisma.Decimal(detail.grossAmount);

--- a/src/config/config.env.ts
+++ b/src/config/config.env.ts
@@ -97,6 +97,12 @@ export class ConfigEnv {
   TOPCODER_WALLET_URL = 'https://wallet.topcoder.com';
 
   @IsInt()
+  @Min(3)
+  @Max(5)
+  @IsOptional()
+  ENGAGEMENT_PAYMENT_RELEASE_WINDOW_DAYS: number = 5;
+
+  @IsInt()
   @Min(0)
   @Max(99)
   @IsOptional()


### PR DESCRIPTION
This pull request introduces support for a configurable release window for engagement payments, ensuring that such payments have a specific delay before being released, as set in the environment configuration.

* Added `ENGAGEMENT_PAYMENT_RELEASE_WINDOW_DAYS` to the environment configuration and validated it in `ConfigEnv` to allow customization of the release window for engagement payments.
* Updated `WinningsService` to calculate and set the `release_date` for engagement payments using the configured window, while keeping the release date `null` for other payment types.