### PR TITLE
[HOTFIX] Handle business verification event

### DIFF
--- a/src/api/webhooks/trolley/handlers/recipient-verification.handler.ts
+++ b/src/api/webhooks/trolley/handlers/recipient-verification.handler.ts
@@ -27,9 +27,14 @@ export class RecipientVerificationHandler {
       where: { trolley_id: payload.recipientId },
     });
 
-    if (payload.type !== RecipientVerificationType.individual) {
+    if (
+      ![
+        RecipientVerificationType.individual,
+        RecipientVerificationType.business,
+      ].includes(payload.type)
+    ) {
       this.logger.log(
-        `Handling only individual status updates, ignoring phone verification for recipient ${payload.recipientId}. Verification type: ${payload.type}.`,
+        `Handling only individual/business status updates, ignoring phone verification for recipient ${payload.recipientId}. Verification type: ${payload.type}.`,
       );
       return;
     }

--- a/src/api/webhooks/trolley/handlers/recipient-verification.types.ts
+++ b/src/api/webhooks/trolley/handlers/recipient-verification.types.ts
@@ -5,6 +5,7 @@ export enum RecipientVerificationWebhookEvent {
 export enum RecipientVerificationType {
   phone = 'phone',
   individual = 'individual',
+  business = 'business',
 }
 
 interface VerifiedIdentityData {


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PM-5564 Wallet app: Members with Business accounts cannot withdraw payments because ID verification remains in "Setup Required" status.

This pull request updates the recipient verification logic to support both individual and business verification types, instead of only handling individual verifications. The main changes are in the webhook handler and the associated type definitions.

**Recipient verification logic improvements:**

* Updated the `RecipientVerificationType` enum to include a new `business` type, allowing the system to recognize business verification events.
* Modified the logic in `RecipientVerificationHandler` to process both `individual` and `business` verification types, instead of just `individual`. The log message was also updated to reflect this broader handling.